### PR TITLE
Fix image_url handling for game creation

### DIFF
--- a/app/api/handle-tool.background/route.ts
+++ b/app/api/handle-tool.background/route.ts
@@ -19,7 +19,6 @@ export async function POST(request: Request) {
       parent,
       verifiedAddress,
       fid,
-      image,
     } = body;
 
     let result;
@@ -38,7 +37,6 @@ export async function POST(request: Request) {
           verifiedAddress,
           fid,
           threadId,
-          image,
           runId,
         });
         console.log('result', result);

--- a/app/api/hurls/route.ts
+++ b/app/api/hurls/route.ts
@@ -299,6 +299,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const fid = author?.fid;
     const image = embeds?.[0]?.url;
 
+    const combinedText = image ? `${text} ${image}` : text;
+
     console.log('Request data:', data);
 
     if (!fid) {
@@ -314,18 +316,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const content: MessageContentPartParam[] = [
       {
         type: 'text',
-        text,
+        text: combinedText,
       },
-      ...(image
-        ? [
-            {
-              type: 'image_url' as const,
-              image_url: {
-                url: image,
-              },
-            },
-          ]
-        : []),
     ];
 
     // --- Conversation Thread Handling ---

--- a/lib/task-handlers.ts
+++ b/lib/task-handlers.ts
@@ -13,7 +13,7 @@ const PLATFORM_REFERRER = process.env.PLATFORM_REFERRER as `0x${string}`;
 export type CreateTaskData = {
   name: string;
   instructions: string;
-  image: string;
+  image_url: string;
   ticker: string;
   parent: string;
   reply: string;
@@ -42,7 +42,7 @@ export type TaskResponse<T> = {
 const createGameSchema = z.object({
   name: z.string().min(1),
   instructions: z.string().min(1),
-  image: z.string().url(),
+  image_url: z.string().url(),
   ticker: z.string().min(1),
   parent: z.string().min(1),
   verifiedAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
@@ -73,7 +73,7 @@ export const taskHandlers = {
       const uri = await ipfsService.pinMetadata(
         validatedData.name,
         validatedData.instructions,
-        validatedData.image
+        validatedData.image_url
       );
 
       // Get wallet clients
@@ -231,7 +231,7 @@ export const taskHandlers = {
                         description: taskData.instructions,
                         code,
                         coin_address: coin.address as `0x${string}`,
-                        image: taskData.image,
+                        image: taskData.image_url,
                         user_fid: taskData.fid,
                       },
                     ])


### PR DESCRIPTION
## Summary
- update `CreateTaskData` and validation to use `image_url`
- append webhook image URL to user message text
- rely on `args.image_url` in background task handler

## Testing
- `npm run lint` *(fails: `next` not found)*