### PR TITLE
Fix user save when wallet not connected

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,8 +16,11 @@ export default function App() {
 
   useEffect(() => {
     const saveUser = async () => {
-      if (context) {
-        const user = context.user;
+      if (!context || !address) {
+        return;
+      }
+
+      const user = context.user;
 
         // Only proceed if user exists and all required fields are present
         if (


### PR DESCRIPTION
## Summary
- only POST `/api/players` after wallet connection

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684621133f908331b40ce2d65aa805a7