### PR TITLE
Refactor player save logic

### DIFF
--- a/app/server-actions.ts
+++ b/app/server-actions.ts
@@ -1,0 +1,30 @@
+'use server';
+
+import { supabaseService } from '@/lib/supabase';
+
+export type PlayerData = {
+  fid: number;
+  name: string;
+  pfp: string;
+  username: string;
+  wallet_address: string;
+};
+
+/**
+ * Upserts player data and awards referral points if needed.
+ * @param player Player information to upsert
+ * @param sharerFid optional referring fid
+ */
+export async function savePlayerAndReferral(
+  player: PlayerData,
+  sharerFid: number | null
+) {
+  const { isNew } = await supabaseService.upsertPlayerWithNewFlag(player);
+
+  if (isNew && sharerFid && sharerFid !== player.fid) {
+    const sharer = await supabaseService.getPlayerByFid(sharerFid);
+    if (sharer && sharer.length > 0) {
+      await supabaseService.incrementPlayerPoints(sharerFid, 5);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- move player saving logic to a new `savePlayerAndReferral` server action
- defer saving until the browser is idle

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846288631348331bb62f7bf6d61dd79