### PR TITLE
Embed Geist font with next/font

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-  font-family: 'Geist', sans-serif;
+  font-family: var(--font-geist-sans), sans-serif;
   font-optical-sizing: auto;
   font-weight: 400;
   font-style: normal;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,14 @@
 import './theme.css';
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
+import { GeistSans } from 'next/font/google';
 import { Providers } from './providers';
 import { Toaster } from '@/components/ui/sonner';
+
+const geistSans = GeistSans({
+  subsets: ['latin'],
+  variable: '--font-geist-sans',
+});
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -39,7 +45,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" className={`${geistSans.variable} dark`}>
       <body className="antialiased bg-gray-900 text-white">
         <Providers>{children}</Providers>
         <Toaster theme="dark" />

--- a/app/theme.css
+++ b/app/theme.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- use `next/font` to load Geist Sans locally in layout
- drop external Google Fonts import
- update global styles to use the font variable

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846288a3c7883318a3d085423a19d0a