### PR TITLE
Fix player points overwrite on upsert

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -120,7 +120,8 @@ export const supabaseService = {
       Pick<Player, 'fid' | 'name' | 'pfp' | 'username' | 'wallet_address'>
   ): Promise<{ data: Player | null; isNew: boolean }> {
     // Use atomic upsert with RPC function to avoid race conditions
-    const { data, error } = await supabase.rpc('upsert_player_with_new_flag', {
+    // Build params without points by default to avoid overwriting existing value
+    const params: Record<string, unknown> = {
       p_fid: record.fid,
       p_name: record.name,
       p_pfp: record.pfp,
@@ -128,8 +129,16 @@ export const supabaseService = {
       p_wallet_address: record.wallet_address,
       p_url: record.url || null,
       p_token: record.token || null,
-      p_points: record.points || null,
-    });
+    };
+
+    if (record.points !== undefined) {
+      params.p_points = record.points;
+    }
+
+    const { data, error } = await supabase.rpc(
+      'upsert_player_with_new_flag',
+      params
+    );
 
     if (error) {
       console.error('Supabase RPC error (upsert_player_with_new_flag):', error);


### PR DESCRIPTION
## Summary
- avoid sending `null` points in the `upsertPlayerWithNewFlag` RPC call

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474020340483318827b6afb89e5d78