### PR TITLE
Apply liquid glass style

### DIFF
--- a/app/components/BuyCoinButton.tsx
+++ b/app/components/BuyCoinButton.tsx
@@ -67,13 +67,13 @@ export function BuyCoinButton({
         onClick={() => writeContract(data!.request)}
         disabled={!data?.request || isPending || isConfirming}
         className={`
-          px-4 py-6 rounded-xl font-medium shadow-md shadow-purple-500/20
+          px-4 py-6 rounded-2xl font-medium shadow-xl shadow-purple-500/20
           ${
             !data?.request || isPending || isConfirming
-              ? 'bg-gray-600 cursor-not-allowed'
-              : 'bg-purple-600 hover:bg-purple-700'
+              ? 'bg-white/10 cursor-not-allowed'
+              : 'bg-purple-600 hover:brightness-110'
           }
-          text-white transition-colors text-xl
+          text-white transition-all duration-200 text-xl
         `}
       >
         {isPending

--- a/app/components/app-init.tsx
+++ b/app/components/app-init.tsx
@@ -160,10 +160,10 @@ export function AppInit() {
 
   if (!isReady) {
     return (
-      <div className="fixed inset-0 z-50 bg-gray-900 flex items-center justify-center">
+      <div className="fixed inset-0 z-50 bg-black flex items-center justify-center">
         <div className="flex flex-col items-center space-y-4">
           <div className="animate-spin rounded-full h-12 w-12 border-2 border-gray-600 border-t-purple-500"></div>
-          <div className="text-gray-300">Loading...</div>
+          <div className="text-white/70">Loading...</div>
         </div>
       </div>
     );

--- a/app/components/coin-card.tsx
+++ b/app/components/coin-card.tsx
@@ -75,12 +75,12 @@ export function CoinCard({ coin }: CoinCardProps) {
   };
 
   return (
-    <div className="border-b border-gray-700 pb-4">
+    <div className="border-b border-white/20 pb-4">
       {/* Post Header */}
       <div className="flex items-center justify-between p-4">
         <div className="flex items-center gap-2">
           <div className="relative">
-            <div className="w-10 h-10 rounded-full bg-gray-700 overflow-hidden">
+            <div className="w-10 h-10 rounded-full bg-white/10 overflow-hidden">
               <Image
                 src={coin.creator?.pfp || '/placeholder.svg?height=40&width=40'}
                 alt={`${coin.creator?.username || 'Creator'} profile`}
@@ -102,19 +102,19 @@ export function CoinCard({ coin }: CoinCardProps) {
           </span>
         </div>
         <div className="flex items-center gap-2">
-          <span className="text-gray-400 text-sm">
+          <span className="text-white/70 text-sm">
             {formatRelativeTime(coin.created_at)}
           </span>
           <Popover>
             <PopoverTrigger asChild>
-              <button className="text-gray-400 hover:text-gray-200 p-1 rounded-full hover:bg-gray-700 transition-colors">
+              <button className="text-white/70 hover:brightness-110 p-1 rounded-full transition-all duration-200">
                 <MoreHorizontal className="w-4 h-4" />
               </button>
             </PopoverTrigger>
-            <PopoverContent className="w-48 p-2 bg-gray-800 border border-gray-700" align="end">
+            <PopoverContent className="w-48 p-2 bg-black/20 backdrop-blur border border-white/20 rounded-2xl shadow-xl" align="end">
               <div className="space-y-1">
                 <button
-                  className="flex items-center gap-3 w-full px-3 py-2 text-sm text-gray-300 hover:bg-gray-700 rounded-md transition-colors"
+                  className="flex items-center gap-3 w-full px-3 py-2 text-sm text-white/70 hover:brightness-110 transition-all duration-200 rounded-md"
                   onClick={handleCopyAddress}
                 >
                   <Copy className="w-4 h-4" />
@@ -126,7 +126,7 @@ export function CoinCard({ coin }: CoinCardProps) {
                   rel="noopener noreferrer"
                   onClick={handleDexScreenerClick}
                 >
-                  <button className="flex items-center gap-3 w-full px-3 py-2 text-sm text-gray-300 hover:bg-gray-700 rounded-md transition-colors">
+                  <button className="flex items-center gap-3 w-full px-3 py-2 text-sm text-white/70 hover:brightness-110 transition-all duration-200 rounded-md">
                     <ExternalLink className="w-4 h-4" />
                     DEX Screener
                   </button>
@@ -156,7 +156,7 @@ export function CoinCard({ coin }: CoinCardProps) {
 
       <Link href={`/coins/${coin.id}`}>
         <button
-          className="bg-purple-600 hover:bg-purple-700 text-white rounded-xl font-semibold transition-colors w-full mt-4 text-xl py-4"
+          className="bg-purple-600 text-white rounded-2xl font-semibold w-full mt-4 text-xl py-4 hover:brightness-110 transition-all duration-200 shadow-xl"
           onClick={handleGameCardView}
         >
           Play

--- a/app/components/coin-leaderboard.tsx
+++ b/app/components/coin-leaderboard.tsx
@@ -75,7 +75,7 @@ export function CoinLeaderboard({
 
   const getRankStyles = (rank: number, isCurrentUser: boolean) => {
     let baseStyles =
-      'flex items-center gap-4 p-4 hover:bg-gray-700 transition-colors';
+      'flex items-center gap-4 p-4 hover:brightness-110 transition-all duration-200';
 
     if (isCurrentUser) {
       baseStyles += ' bg-purple-900/30 border-l-4 border-purple-500';
@@ -131,8 +131,8 @@ export function CoinLeaderboard({
         </h2>
         <div className="text-center py-8">
           <Trophy className="w-12 h-12 text-gray-600 mx-auto mb-3" />
-          <p className="text-gray-400 text-sm">No players yet</p>
-          <p className="text-gray-500 text-xs mt-1">
+          <p className="text-white/70 text-sm">No players yet</p>
+          <p className="text-white/60 text-xs mt-1">
             Be the first to play and earn points!
           </p>
         </div>
@@ -148,7 +148,7 @@ export function CoinLeaderboard({
         </h2>
         <button
           onClick={handleShareLeaderboard}
-          className="flex items-center gap-1 px-3 py-2 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded-md transition-colors"
+          className="flex items-center gap-1 px-3 py-2 text-xs bg-white/10 backdrop-blur border border-white/20 rounded-2xl text-white hover:brightness-110 transition-all duration-200"
           title="Share leaderboard"
         >
           <Share2 className="w-3 h-3" />
@@ -156,7 +156,7 @@ export function CoinLeaderboard({
         </button>
       </div>
 
-      <div className="bg-gray-800 rounded-xl overflow-hidden border border-gray-700">
+      <div className="bg-black/20 backdrop-blur rounded-2xl overflow-hidden border border-white/20 shadow-xl">
         <div className="divide-y divide-gray-700">
           {leaderboard.map((player) => {
             const isCurrentUser = context?.user?.fid === player.fid;
@@ -167,7 +167,7 @@ export function CoinLeaderboard({
                 className={getRankStyles(player.rank, isCurrentUser)}
               >
                 {/* Rank */}
-                <div className="flex items-center justify-center w-10 h-10 rounded-full bg-gray-700 text-sm font-bold">
+                <div className="flex items-center justify-center w-10 h-10 rounded-full bg-white/10 text-sm font-bold">
                   {getRankDisplay(player.rank)}
                 </div>
 
@@ -207,21 +207,21 @@ export function CoinLeaderboard({
                   {player.name && player.username && (
                     <button
                       onClick={() => handleViewProfile(player.fid)}
-                      className="text-sm text-gray-400 hover:text-blue-400 transition-colors truncate text-left block"
+                      className="text-sm text-white/70 hover:brightness-110 transition-all duration-200 truncate text-left block"
                       title="View profile"
                     >
                       @{player.username}
                     </button>
                   )}
                   <div className="flex items-center justify-between mt-1">
-                    <div className="text-xs text-gray-500">
+                    <div className="text-xs text-white/60">
                       {player.play_count}{' '}
                       {player.play_count === 1 ? 'play' : 'plays'}
                     </div>
                     {isCurrentUser && (
                       <button
                         onClick={() => handleSharePosition(player)}
-                        className="flex items-center gap-1 px-2 py-1 text-xs bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
+                        className="flex items-center gap-1 px-2 py-1 text-xs bg-blue-600 text-white rounded-2xl hover:brightness-110 transition-all duration-200"
                         title="Share your leaderboard position"
                       >
                         <Share2 className="w-3 h-3" />
@@ -236,7 +236,7 @@ export function CoinLeaderboard({
                   <div className="font-bold text-lg text-white">
                     {player.total_score.toLocaleString()}
                   </div>
-                  <div className="text-xs text-gray-400">points</div>
+                  <div className="text-xs text-white/70">points</div>
                 </div>
               </div>
             );
@@ -246,7 +246,7 @@ export function CoinLeaderboard({
 
       {leaderboard.length >= (limit || 10) && (
         <div className="text-center mt-4">
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-white/60">
             Showing top {limit || 10} players
           </p>
         </div>

--- a/app/components/coins-list.tsx
+++ b/app/components/coins-list.tsx
@@ -73,14 +73,14 @@ export async function CoinsList() {
   } catch (error) {
     console.error('Error fetching coins with creators and Zora data:', error);
     return (
-      <div className="text-center text-red-400 py-8 bg-gray-900">
+      <div className="text-center text-red-400 py-8 bg-black/20 backdrop-blur rounded-2xl border border-white/20 shadow-xl mx-4 mt-4">
         <p>Failed to load coins</p>
       </div>
     );
   }
 
   return (
-    <main className="flex-1 overflow-auto container mx-auto px-4 py-12 max-w-6xl pt-20 bg-gray-900">
+    <main className="flex-1 overflow-auto container mx-auto px-4 py-12 pt-20 flex flex-col gap-4">
       {coins.map((coin) => (
         <CoinCard key={coin.id} coin={coin} />
       ))}

--- a/app/components/game-wrapper.tsx
+++ b/app/components/game-wrapper.tsx
@@ -192,10 +192,10 @@ export function GameWrapper({
 
   if (isLoadingZoraData) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-black flex items-center justify-center">
         <div className="flex flex-col items-center space-y-4">
           <div className="animate-spin rounded-full h-12 w-12 border-2 border-gray-600 border-t-purple-500"></div>
-          <div className="text-gray-300">Loading...</div>
+          <div className="text-white/70">Loading...</div>
         </div>
       </div>
     );
@@ -204,19 +204,19 @@ export function GameWrapper({
   if (showGame) {
     return (
       <div className="flex flex-col h-full">
-        <header className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between p-2 border-b border-gray-700 bg-gray-900">
+        <header className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between p-2 backdrop-blur-md bg-black/20 border-b border-white/20 shadow-xl">
           <Button
             variant="ghost"
             size="sm"
             onClick={handleGameExit}
-            className="flex items-center gap-2 text-gray-400 hover:text-gray-100"
+            className="flex items-center gap-2 text-white/70 hover:brightness-110 transition-all duration-200"
           >
             <ArrowLeft size={20} />
             <span>Exit</span>
           </Button>
 
           {timeoutSeconds && (
-            <div className="flex items-center gap-2 text-gray-400">
+            <div className="flex items-center gap-2 text-white/70">
               <Clock size={16} />
               <span className="text-sm font-mono">
                 {Math.floor(remainingTime / 60)}:

--- a/app/components/game.tsx
+++ b/app/components/game.tsx
@@ -168,8 +168,8 @@ export function Game({
 
   if (!id) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
-        <div className="text-gray-300">Please enter a game id</div>
+      <div className="min-h-screen bg-black flex items-center justify-center">
+        <div className="text-white/70">Please enter a game id</div>
       </div>
     );
   }
@@ -184,10 +184,10 @@ export function Game({
 
   if (!isReady || checkingTokens || checkingPlayStatus) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-black flex items-center justify-center">
         <div className="flex flex-col items-center space-y-4">
           <div className="animate-spin rounded-full h-12 w-12 border-2 border-gray-600 border-t-purple-500"></div>
-          <div className="text-gray-300">Loading...</div>
+          <div className="text-white/70">Loading...</div>
         </div>
       </div>
     );
@@ -196,11 +196,11 @@ export function Game({
   if (isGameOver) {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-sm">
-        <div className="text-center p-8 rounded-2xl bg-gray-800/80 border border-gray-700 max-w-md w-full mx-4">
+        <div className="text-center p-8 rounded-2xl bg-black/80 backdrop-blur border border-white/20 shadow-xl max-w-md w-full mx-4">
           <h1 className="text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-pink-500 mb-4">
             Game Over
           </h1>
-          <p className="text-xl text-gray-300 mb-4">{`Time's up!`}</p>
+          <p className="text-xl text-white/70 mb-4">{`Time's up!`}</p>
 
           {!hasPlayedBefore ? (
             // First-time player - encourage them to get tokens for full access
@@ -214,7 +214,7 @@ export function Game({
               {!isConnected ? (
                 <button
                   onClick={() => connect({ connector: connectors[0] })}
-                  className="w-full py-3 px-6 text-lg font-semibold rounded-xl bg-purple-600 hover:bg-purple-700 text-white transition-colors"
+                  className="w-full py-3 px-6 text-lg font-semibold rounded-2xl bg-purple-600 text-white hover:brightness-110 transition-all duration-200"
                 >
                   Connect Wallet
                 </button>
@@ -239,7 +239,7 @@ export function Game({
               </p>
               <button
                 onClick={() => setIsGameOver(false)}
-                className="w-full py-3 px-6 text-lg font-semibold rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white transition-colors"
+                className="w-full py-3 px-6 text-lg font-semibold rounded-2xl bg-emerald-600 text-white hover:brightness-110 transition-all duration-200"
               >
                 Play Again
               </button>
@@ -253,7 +253,7 @@ export function Game({
               {!isConnected ? (
                 <button
                   onClick={() => connect({ connector: connectors[0] })}
-                  className="w-full py-3 px-6 text-lg font-semibold rounded-xl bg-purple-600 hover:bg-purple-700 text-white transition-colors"
+                  className="w-full py-3 px-6 text-lg font-semibold rounded-2xl bg-purple-600 text-white hover:brightness-110 transition-all duration-200"
                 >
                   Connect Wallet
                 </button>
@@ -276,12 +276,12 @@ export function Game({
   }
 
   return (
-    <div className="fixed inset-0 z-50 left-0 w-full h-full bg-gray-900 top-12">
+    <div className="fixed inset-0 z-50 left-0 w-full h-full bg-black top-12">
       {loading && (
-        <div className="absolute inset-0 flex items-center justify-center bg-gray-900">
+        <div className="absolute inset-0 flex items-center justify-center bg-black">
           <div className="flex flex-col items-center space-y-4">
             <div className="animate-spin rounded-full h-12 w-12 border-2 border-gray-600 border-t-purple-500"></div>
-            <p className="text-gray-300">Loading game...</p>
+            <p className="text-white/70">Loading game...</p>
           </div>
         </div>
       )}

--- a/app/components/header-profile.tsx
+++ b/app/components/header-profile.tsx
@@ -171,7 +171,7 @@ export function HeaderProfile() {
       <Button
         onClick={handleConnect}
         disabled={isConnecting}
-        className="flex items-center gap-2 bg-purple-600 hover:bg-purple-700 text-white border-purple-600"
+        className="flex items-center gap-2 bg-purple-600 hover:brightness-110 transition-all duration-200 text-white border border-white/20 rounded-2xl shadow-xl"
         variant="outline"
       >
         <Wallet className="w-4 h-4" />
@@ -185,12 +185,12 @@ export function HeaderProfile() {
   return (
     <Drawer>
       <DrawerTrigger asChild>
-        <List className="w-6 h-6 text-gray-400 hover:text-purple-400 transition-colors cursor-pointer" />
+        <List className="w-6 h-6 text-white/70 hover:brightness-110 transition-all duration-200 cursor-pointer" />
       </DrawerTrigger>
-      <DrawerContent className="bg-gray-900 border-gray-700">
+      <DrawerContent className="bg-black/20 backdrop-blur-md border border-white/20 rounded-2xl shadow-xl">
         <div className="flex flex-col h-full">
           {/* Profile Section */}
-          <div className="p-6 border-b border-gray-700">
+          <div className="p-6 border-b border-white/20">
             <div className="flex items-center gap-3">
               <div className="w-12 h-12 rounded-full bg-gradient-to-br from-purple-400 to-purple-600 overflow-hidden">
                 {userPfp ? (
@@ -226,7 +226,7 @@ export function HeaderProfile() {
                 {address && (
                   <button
                     onClick={() => copyAddress(address)}
-                    className="flex items-center gap-1 text-sm text-gray-400 hover:text-purple-400 transition-colors self-start"
+                    className="flex items-center gap-1 text-sm text-white/70 hover:brightness-110 transition-all duration-200 self-start"
                   >
                     <span>{formatAddress(address)}</span>
                     <Copy className="w-3 h-3" />
@@ -240,14 +240,14 @@ export function HeaderProfile() {
             {/* Menu Items */}
             <div className="space-y-6">
               <Link href="/" onClick={handleGamesNavigation}>
-                <div className="flex items-center gap-4 text-xl font-semibold text-white hover:text-purple-400 transition-colors">
+                <div className="flex items-center gap-4 text-xl font-semibold text-white hover:brightness-110 transition-all duration-200">
                   <Sparkles className="w-6 h-6" />
                   <span>Games</span>
                 </div>
               </Link>
 
               <Link
-                className="flex items-center gap-4 text-xl font-semibold text-white hover:text-purple-400 transition-colors cursor-pointer"
+                className="flex items-center gap-4 text-xl font-semibold text-white hover:brightness-110 transition-all duration-200 cursor-pointer"
                 href="/leaderboard"
                 onClick={handleLeaderboardNavigation}
               >
@@ -257,7 +257,7 @@ export function HeaderProfile() {
 
               <button
                 onClick={handleShareReferral}
-                className="flex items-center gap-4 text-xl font-semibold text-white hover:text-purple-400 transition-colors"
+                className="flex items-center gap-4 text-xl font-semibold text-white hover:brightness-110 transition-all duration-200"
               >
                 <Share2 className="w-6 h-6" />
                 <span>Invite Friends</span>
@@ -270,7 +270,7 @@ export function HeaderProfile() {
           <DrawerClose asChild>
             <Button
               variant="outline"
-              className="bg-gray-800 border-gray-600 text-white hover:bg-gray-700"
+              className="bg-white/10 backdrop-blur border border-white/20 rounded-2xl text-white hover:brightness-110 transition-all duration-200"
             >
               Close
             </Button>

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -11,8 +11,8 @@ export function Header() {
   };
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between p-4 border-b border-gray-700 bg-gray-900">
-      <Link href="/" onClick={handleHomeClick}>
+    <header className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between p-4 backdrop-blur-md bg-black/20 border-b border-white/20 shadow-xl">
+      <Link href="/" onClick={handleHomeClick} className="hover:brightness-110 transition-all duration-200">
         <Sparkles className="w-6 h-6 text-purple-400" />
       </Link>
       <HeaderProfile />

--- a/app/components/info.tsx
+++ b/app/components/info.tsx
@@ -103,9 +103,9 @@ export function Info({
 
   if (!name) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center p-4">
-        <div className="bg-gray-800 rounded-2xl shadow-sm p-8 text-center max-w-md border border-gray-700">
-          <div className="text-gray-300">Please enter a game name</div>
+      <div className="min-h-screen bg-black flex items-center justify-center p-4">
+        <div className="bg-black/20 backdrop-blur rounded-2xl shadow-xl p-8 text-center max-w-md border border-white/20">
+          <div className="text-white/70">Please enter a game name</div>
         </div>
       </div>
     );
@@ -113,9 +113,9 @@ export function Info({
 
   if (!description) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center p-4">
-        <div className="bg-gray-800 rounded-2xl shadow-sm p-8 text-center max-w-md border border-gray-700">
-          <div className="text-gray-300">Please enter a game description</div>
+      <div className="min-h-screen bg-black flex items-center justify-center p-4">
+        <div className="bg-black/20 backdrop-blur rounded-2xl shadow-xl p-8 text-center max-w-md border border-white/20">
+          <div className="text-white/70">Please enter a game description</div>
         </div>
       </div>
     );
@@ -123,11 +123,11 @@ export function Info({
 
   if (!isReady || isLoading || !hasCheckedStatus) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center p-4">
-        <div className="bg-gray-800 rounded-2xl shadow-sm p-8 text-center max-w-md border border-gray-700">
+      <div className="min-h-screen bg-black flex items-center justify-center p-4">
+        <div className="bg-black/20 backdrop-blur rounded-2xl shadow-xl p-8 text-center max-w-md border border-white/20">
           <div className="flex flex-col items-center space-y-4">
             <div className="animate-spin rounded-full h-8 w-8 border-2 border-gray-600 border-t-blue-400"></div>
-            <div className="text-gray-300">Loading...</div>
+            <div className="text-white/70">Loading...</div>
           </div>
         </div>
       </div>
@@ -136,10 +136,10 @@ export function Info({
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center p-4">
-        <div className="bg-gray-800 rounded-2xl shadow-sm p-8 text-center max-w-md border border-gray-700">
+      <div className="min-h-screen bg-black flex items-center justify-center p-4">
+        <div className="bg-black/20 backdrop-blur rounded-2xl shadow-xl p-8 text-center max-w-md border border-white/20">
           <div className="text-red-400 font-medium">Error</div>
-          <div className="text-gray-300 mt-2">{error}</div>
+          <div className="text-white/70 mt-2">{error}</div>
         </div>
       </div>
     );
@@ -147,9 +147,9 @@ export function Info({
 
   if (!playStatus) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center p-4">
-        <div className="bg-gray-800 rounded-2xl shadow-sm p-8 text-center max-w-md border border-gray-700">
-          <div className="text-gray-300">Unable to check play status</div>
+      <div className="min-h-screen bg-black flex items-center justify-center p-4">
+        <div className="bg-black/20 backdrop-blur rounded-2xl shadow-xl p-8 text-center max-w-md border border-white/20">
+          <div className="text-white/70">Unable to check play status</div>
         </div>
       </div>
     );
@@ -158,10 +158,10 @@ export function Info({
   // Show different UI based on play status
   if (!playStatus.canPlay) {
     return (
-      <div className="min-h-screen bg-gray-900">
-        <div className="max-w-lg mx-auto bg-gray-900">
+      <div className="min-h-screen bg-black">
+      <div className="max-w-lg mx-auto bg-gradient-to-b from-black via-zinc-900 to-black">
           {/* Header with app icon and basic info */}
-          <div className="p-6 border-b border-gray-700">
+          <div className="p-6 border-b border-white/20">
             <div className="flex items-start space-x-4">
               {/* App Icon */}
               <div className="w-24 h-24 rounded-2xl overflow-hidden shadow-lg bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center flex-shrink-0">
@@ -191,7 +191,7 @@ export function Info({
                 <h1 className="text-2xl font-bold text-white leading-tight">
                   {name}
                 </h1>
-                <p className="text-sm text-gray-400 mt-1">${symbol}</p>
+                <p className="text-sm text-white/70 mt-1">${symbol}</p>
 
                 {/* Token Statistics */}
                 <div className="flex items-center gap-3 text-sm pt-2">
@@ -332,20 +332,20 @@ export function Info({
           </div>
 
           {/* Description */}
-          <div className="p-6 border-t border-gray-700">
+          <div className="p-6 border-t border-white/20">
             <h2 className="text-lg font-semibold text-white mb-3">
               About this game
             </h2>
-            <p className="text-sm text-gray-300 leading-relaxed">
+            <p className="text-sm text-white/70 leading-relaxed">
               {description}
             </p>
           </div>
 
           {/* Creator */}
-          <div className="p-6 border-t border-gray-700">
+          <div className="p-6 border-t border-white/20">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-3">
-                <div className="w-10 h-10 rounded-full bg-gray-700 overflow-hidden">
+                <div className="w-10 h-10 rounded-full bg-white/10 overflow-hidden">
                   {creator?.pfp ? (
                     <img
                       src={creator.pfp}
@@ -364,7 +364,7 @@ export function Info({
                   <p className="text-sm font-medium text-white">
                     {creator?.username || `Creator ${fid}`}
                   </p>
-                  <p className="text-xs text-gray-400">Game Creator</p>
+                  <p className="text-xs text-white/70">Game Creator</p>
                 </div>
               </div>
               <button
@@ -385,11 +385,11 @@ export function Info({
 
   // Player can play - show the normal play button
   return (
-    <div className="min-h-screen bg-gray-900">
+    <div className="min-h-screen bg-black">
       <Header />
-      <div className="max-w-lg mx-auto bg-gray-900 pt-14">
+      <div className="max-w-lg mx-auto bg-gradient-to-b from-black via-zinc-900 to-black pt-14">
         {/* Header with app icon and basic info */}
-        <div className="p-6 border-b border-gray-700">
+        <div className="p-6 border-b border-white/20">
           <div className="flex items-start space-x-4">
             {/* App Icon */}
             <div className="w-24 h-24 rounded-2xl overflow-hidden shadow-lg bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center flex-shrink-0">
@@ -419,7 +419,7 @@ export function Info({
               <h1 className="text-2xl font-bold text-white leading-tight">
                 {name}
               </h1>
-              <p className="text-sm text-gray-400 mt-1">${symbol}</p>
+              <p className="text-sm text-white/70 mt-1">${symbol}</p>
 
               {/* Token Statistics */}
               <div className="flex items-center gap-3 text-sm pt-2">
@@ -543,21 +543,21 @@ export function Info({
         )}
 
         {/* Description */}
-        <div className="p-6 border-t border-gray-700 flex flex-col gap-6 items-center">
-          <p className="text-sm text-gray-300 leading-relaxed">{description}</p>
+        <div className="p-6 border-t border-white/20 flex flex-col gap-6 items-center">
+          <p className="text-sm text-white/70 leading-relaxed">{description}</p>
           <button
             onClick={handlePlay}
-            className="w-full bg-purple-600 hover:bg-purple-700 text-white px-4 py-4 rounded-xl font-semibold shadow-md shadow-purple-500/20 text-lg"
+            className="w-full bg-purple-600 text-white px-4 py-4 rounded-2xl font-semibold shadow-xl shadow-purple-500/20 hover:brightness-110 transition-all duration-200 text-lg"
           >
             PLAY
           </button>
         </div>
 
         {/* Creator */}
-        <div className="p-6 border-t border-gray-700">
+        <div className="p-6 border-t border-white/20">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-3">
-              <div className="w-10 h-10 rounded-full bg-gray-700 overflow-hidden">
+              <div className="w-10 h-10 rounded-full bg-white/10 overflow-hidden">
                 {creator?.pfp ? (
                   <img
                     src={creator.pfp}
@@ -576,7 +576,7 @@ export function Info({
                 <p className="text-sm font-medium text-white">
                   {creator?.username || `Creator ${fid}`}
                 </p>
-                <p className="text-xs text-gray-400">Game Creator</p>
+                <p className="text-xs text-white/70">Game Creator</p>
               </div>
             </div>
             <button

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -46,7 +46,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${inter.variable} dark`}>
-      <body className="antialiased bg-gray-900 text-white">
+      <body className="antialiased bg-black text-white">
         <Providers>{children}</Providers>
         <Toaster theme="dark" />
       </body>

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -73,22 +73,22 @@ export default function LeaderboardPage() {
   }, []);
 
   return (
-    <div className="max-w-lg mx-auto bg-gray-900 min-h-screen flex flex-col">
+    <div className="max-w-lg mx-auto min-h-screen flex flex-col bg-gradient-to-b from-black via-zinc-900 to-black text-white">
       <Header />
       <div className="px-4 pt-20 pb-8">
         <div className="text-center mb-8">
           <h1 className="text-xl font-bold text-white mb-2">Player Rankings</h1>
-          <p className="text-gray-400">
+          <p className="text-white/70">
             See how you stack up against other players
           </p>
           {playerStats && context?.user?.fid && (
             <button
               onClick={handleShareRank}
               disabled={isSharing}
-              className={`mt-4 inline-flex items-center gap-1 px-3 py-2 text-xs rounded-md text-white transition-colors ${
+              className={`mt-4 inline-flex items-center gap-1 px-3 py-2 text-xs rounded-2xl text-white transition-all duration-200 border border-white/20 backdrop-blur ${
                 isSharing
-                  ? 'bg-gray-600 cursor-not-allowed opacity-50'
-                  : 'bg-gray-700 hover:bg-gray-600'
+                  ? 'bg-white/10 cursor-not-allowed opacity-50'
+                  : 'bg-white/10 hover:brightness-110'
               }`}
             >
               <Share2
@@ -102,14 +102,14 @@ export default function LeaderboardPage() {
         <div className="space-y-6">
           {/* Top 10 Leaderboard */}
           <div>
-            <h2 className="text-sm font-semibold text-gray-200 mb-4">
+            <h2 className="text-sm font-semibold text-white mb-4">
               Top 5 Players
             </h2>
             <Leaderboard limit={5} />
           </div>
           {/* Full Leaderboard */}
           <div>
-            <h2 className="text-sm font-semibold text-gray-200 mb-4">
+            <h2 className="text-sm font-semibold text-white mb-4">
               All Players
             </h2>
             <Leaderboard />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { AppInit } from './components/app-init';
 
 export default function Page() {
   return (
-    <div className="max-w-lg mx-auto bg-gray-900 min-h-screen flex flex-col">
+    <div className="max-w-lg mx-auto min-h-screen flex flex-col bg-gradient-to-b from-black via-zinc-900 to-black text-white">
       <AppInit />
       <Header />
       <CoinsList />

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -68,22 +68,22 @@ export function Leaderboard({
       return 'bg-gradient-to-r from-gray-300 to-gray-500 text-white';
     if (rank === 3)
       return 'bg-gradient-to-r from-amber-600 to-amber-800 text-white';
-    return 'bg-gray-700 text-gray-200';
+    return 'bg-white/10 text-white/80';
   };
 
   if (isLoading) {
     return (
-      <div className="w-full bg-gray-800 rounded-xl shadow-lg p-6">
+      <div className="w-full bg-black/20 backdrop-blur rounded-2xl shadow-xl p-6 border border-white/20">
         <div className="animate-pulse space-y-4">
-          <div className="h-6 bg-gray-700 rounded w-1/3"></div>
+          <div className="h-6 bg-white/20 rounded w-1/3"></div>
           {[...Array(5)].map((_, i) => (
             <div key={i} className="flex items-center space-x-4">
-              <div className="w-12 h-12 bg-gray-700 rounded-full"></div>
+              <div className="w-12 h-12 bg-white/20 rounded-full"></div>
               <div className="flex-1 space-y-2">
-                <div className="h-4 bg-gray-700 rounded w-1/2"></div>
-                <div className="h-3 bg-gray-700 rounded w-1/4"></div>
+                <div className="h-4 bg-white/20 rounded w-1/2"></div>
+                <div className="h-3 bg-white/20 rounded w-1/4"></div>
               </div>
-              <div className="h-6 bg-gray-700 rounded w-16"></div>
+              <div className="h-6 bg-white/20 rounded w-16"></div>
             </div>
           ))}
         </div>
@@ -93,12 +93,12 @@ export function Leaderboard({
 
   if (error) {
     return (
-      <div className="w-full bg-gray-800 rounded-xl shadow-lg p-6">
+      <div className="w-full bg-black/20 backdrop-blur rounded-2xl shadow-xl p-6 border border-white/20">
         <div className="text-center py-8">
           <div className="text-red-400 text-lg font-medium">
             Failed to load leaderboard
           </div>
-          <div className="text-gray-400 text-sm mt-2">{error}</div>
+          <div className="text-white/70 text-sm mt-2">{error}</div>
         </div>
       </div>
     );
@@ -109,13 +109,13 @@ export function Leaderboard({
     leaderboard.some((player) => player.fid === currentPlayerRank.fid);
 
   return (
-    <div className="w-full bg-gray-800 rounded-xl shadow-lg overflow-hidden border border-gray-700">
+    <div className="w-full bg-black/20 backdrop-blur rounded-2xl shadow-xl overflow-hidden border border-white/20">
       {/* Leaderboard List */}
       <div className="divide-y divide-gray-700">
         {leaderboard.map((player) => (
           <div
             key={player.fid}
-            className={`flex items-center gap-4 p-4 hover:bg-gray-700 transition-colors ${
+            className={`flex items-center gap-4 p-4 hover:brightness-110 transition-all duration-200 ${
               currentPlayerFid === player.fid
                 ? 'bg-purple-900/30 border-l-4 border-purple-500'
                 : ''
@@ -133,13 +133,13 @@ export function Leaderboard({
               <img
                 src={player.pfp || '/default-avatar.svg'}
                 alt={`${player.username || player.name}'s avatar`}
-                className="w-12 h-12 rounded-full object-cover border-2 border-gray-600"
+                className="w-12 h-12 rounded-full object-cover border-2 border-white/20"
                 onError={(e) => {
                   e.currentTarget.src = '/default-avatar.svg';
                 }}
               />
               {player.rank <= 3 && (
-                <div className="absolute -top-1 -right-1 w-6 h-6 bg-gray-800 rounded-full flex items-center justify-center shadow-sm border border-gray-600">
+                <div className="absolute -top-1 -right-1 w-6 h-6 bg-black/50 rounded-full flex items-center justify-center shadow-sm border border-white/20">
                   <span className="text-xs">{getRankDisplay(player.rank)}</span>
                 </div>
               )}
@@ -151,7 +151,7 @@ export function Leaderboard({
                 {player.name || player.username}
               </div>
               {player.name && player.username && (
-                <div className="text-sm text-gray-400 truncate">
+                <div className="text-sm text-white/70 truncate">
                   @{player.username}
                 </div>
               )}
@@ -162,7 +162,7 @@ export function Leaderboard({
               <div className="font-bold text-lg text-white">
                 {player.points.toLocaleString()}
               </div>
-              <div className="text-xs text-gray-400">points</div>
+              <div className="text-xs text-white/70">points</div>
             </div>
           </div>
         ))}
@@ -171,9 +171,9 @@ export function Leaderboard({
       {/* Current Player Section (if not in top list) */}
       {showCurrentPlayer && currentPlayerRank && !isCurrentPlayerInTop && (
         <>
-          <div className="border-t-2 border-dashed border-gray-600 my-2"></div>
+          <div className="border-t-2 border-dashed border-white/20 my-2"></div>
           <div className="px-4 pb-4">
-            <div className="text-xs text-gray-400 mb-2 text-center">
+            <div className="text-xs text-white/70 mb-2 text-center">
               Your Rank
             </div>
             <div className="flex items-center gap-4 p-3 bg-purple-900/20 rounded-lg border border-purple-500/30">
@@ -198,7 +198,7 @@ export function Leaderboard({
                   {currentPlayerRank.name || currentPlayerRank.username}
                 </div>
                 {currentPlayerRank.name && currentPlayerRank.username && (
-                  <div className="text-sm text-gray-400 truncate">
+                  <div className="text-sm text-white/70 truncate">
                     @{currentPlayerRank.username}
                   </div>
                 )}
@@ -209,7 +209,7 @@ export function Leaderboard({
                 <div className="font-bold text-lg text-white">
                   {currentPlayerRank.points.toLocaleString()}
                 </div>
-                <div className="text-xs text-gray-400">points</div>
+                <div className="text-xs text-white/70">points</div>
               </div>
             </div>
           </div>
@@ -219,8 +219,8 @@ export function Leaderboard({
       {/* Empty State */}
       {leaderboard.length === 0 && (
         <div className="text-center py-12">
-          <div className="text-gray-400 text-lg">No players found</div>
-          <div className="text-gray-500 text-sm mt-2">
+          <div className="text-white/70 text-lg">No players found</div>
+          <div className="text-white/60 text-sm mt-2">
             Start playing to appear on the leaderboard!
           </div>
         </div>


### PR DESCRIPTION
## Summary
- update layout and pages with glassmorphic backgrounds
- tweak header and drawer with translucent styling
- refine coin cards and lists for mobile
- polish leaderboard pages with soft borders
- unify loading overlays and buttons

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847688cd1f8833190a8d6368e642f9a