### PR TITLE
Enable copying of coin links

### DIFF
--- a/app/components/coin-card.tsx
+++ b/app/components/coin-card.tsx
@@ -9,6 +9,7 @@ import {
   TrendingUp,
   DollarSign,
   Users,
+  Link as LinkIcon,
 } from 'lucide-react';
 import { CoinWithCreator } from '@/lib/types';
 import { formatRelativeTime, formatCurrency, formatHolders } from '@/lib/utils';
@@ -38,6 +39,25 @@ export function CoinCard({ coin }: CoinCardProps) {
         {
           action: 'copy_address',
           element: 'coin_address',
+          page: 'coins_list',
+        }
+      );
+    }
+  };
+
+  const handleCopyLink = () => {
+    try {
+      const link = `https://app.minigames.studio/coins/${coin.id}`;
+      navigator.clipboard.writeText(link);
+      toast.success('Link copied to clipboard!');
+      trackGameEvent.coinLinkCopy(coin.id, coin.name);
+    } catch (error) {
+      toast.error('Failed to copy link');
+      sentryTracker.userActionError(
+        error instanceof Error ? error : new Error('Failed to copy link'),
+        {
+          action: 'copy_link',
+          element: 'coin_link',
           page: 'coins_list',
         }
       );
@@ -133,6 +153,13 @@ export function CoinCard({ coin }: CoinCardProps) {
                 >
                   <Copy className="w-4 h-4" />
                   Copy address
+                </button>
+                <button
+                  className="flex items-center gap-3 w-full px-3 py-2 text-sm text-white/70 hover:brightness-110 transition-all duration-200 rounded-md"
+                  onClick={handleCopyLink}
+                >
+                  <LinkIcon className="w-4 h-4" />
+                  Copy link
                 </button>
                 <Link
                   href={`https://dexscreener.com/base/${coin.coin_address}`}

--- a/app/components/info.tsx
+++ b/app/components/info.tsx
@@ -14,11 +14,15 @@ import {
   Trophy,
   Coins,
   Share2,
+  Copy,
 } from 'lucide-react';
 import { formatCurrency, formatHolders, formatTokenBalance } from '@/lib/utils';
 import { sdk } from '@farcaster/frame-sdk';
 import { Header } from './header';
 import { CoinLeaderboard } from './coin-leaderboard';
+import { toast } from 'sonner';
+import { trackGameEvent } from '@/lib/posthog';
+import { sentryTracker } from '@/lib/sentry';
 
 interface InfoProps {
   name: string;
@@ -94,6 +98,25 @@ export function Info({
       });
     } catch (error) {
       console.error('Failed to share:', error);
+    }
+  };
+
+  const handleCopyLink = () => {
+    try {
+      const link = `https://app.minigames.studio/coins/${coinId}`;
+      navigator.clipboard.writeText(link);
+      toast.success('Link copied to clipboard!');
+      trackGameEvent.coinLinkCopy(coinId, name);
+    } catch (error) {
+      toast.error('Failed to copy link');
+      sentryTracker.userActionError(
+        error instanceof Error ? error : new Error('Failed to copy link'),
+        {
+          action: 'copy_link',
+          element: 'coin_link',
+          page: 'coin_info',
+        }
+      );
     }
   };
 
@@ -531,6 +554,13 @@ export function Info({
                   >
                     <Share2 className="w-3.5 h-3.5" />
                     Share
+                  </button>
+                  <button
+                    onClick={handleCopyLink}
+                    className="flex items-center justify-center gap-2 py-1 px-3 bg-white/10 hover:brightness-110 text-white text-xs font-medium rounded-full transition-colors"
+                  >
+                    <Copy className="w-3.5 h-3.5" />
+                    Copy Link
                   </button>
                 </div>
               </div>

--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -133,6 +133,13 @@ export const trackGameEvent = {
     });
   },
 
+  coinLinkCopy: (coinId: string, coinName: string) => {
+    trackEvent('coin_link_copied', {
+      coin_id: coinId,
+      coin_name: coinName,
+    });
+  },
+
   dexScreenerClick: (coinAddress: string, coinName: string) => {
     trackEvent('dex_screener_clicked', {
       coin_address: coinAddress,


### PR DESCRIPTION
## Summary
- add `coinLinkCopy` event tracking
- add copy coin link option to each coin card
- allow copying link from coin info page

## Testing
- `yarn lint` *(fails: package isn't installed)*
- `yarn build` *(fails: package isn't installed)*

------
https://chatgpt.com/codex/tasks/task_e_68487445696c833186b266e832313046