### PR TITLE
Remove copy link button from Info component

### DIFF
--- a/app/components/info.tsx
+++ b/app/components/info.tsx
@@ -14,7 +14,6 @@ import {
   Trophy,
   Coins,
   Share2,
-  Copy,
 } from 'lucide-react';
 import { formatCurrency, formatHolders, formatTokenBalance } from '@/lib/utils';
 import { sdk } from '@farcaster/frame-sdk';
@@ -98,25 +97,6 @@ export function Info({
       });
     } catch (error) {
       console.error('Failed to share:', error);
-    }
-  };
-
-  const handleCopyLink = () => {
-    try {
-      const link = `https://app.minigames.studio/coins/${coinId}`;
-      navigator.clipboard.writeText(link);
-      toast.success('Link copied to clipboard!');
-      trackGameEvent.coinLinkCopy(coinId, name);
-    } catch (error) {
-      toast.error('Failed to copy link');
-      sentryTracker.userActionError(
-        error instanceof Error ? error : new Error('Failed to copy link'),
-        {
-          action: 'copy_link',
-          element: 'coin_link',
-          page: 'coin_info',
-        }
-      );
     }
   };
 
@@ -554,13 +534,6 @@ export function Info({
                   >
                     <Share2 className="w-3.5 h-3.5" />
                     Share
-                  </button>
-                  <button
-                    onClick={handleCopyLink}
-                    className="flex items-center justify-center gap-2 py-1 px-3 bg-white/10 hover:brightness-110 text-white text-xs font-medium rounded-full transition-colors"
-                  >
-                    <Copy className="w-3.5 h-3.5" />
-                    Copy Link
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- remove the copy link handler and button
- clean up unused imports

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487810e4548331bebc87e6078184f5