### PR TITLE
Fix useFarcasterContext auto add frame check

### DIFF
--- a/hooks/useFarcasterContext.ts
+++ b/hooks/useFarcasterContext.ts
@@ -42,7 +42,7 @@ export function useFarcasterContext(options: UseFarcasterContextOptions = {}) {
 
   useEffect(() => {
     const handleAddFrame = async () => {
-      if (context && !context.client?.added) {
+      if (context && options.autoAddFrame && !context.client?.added) {
         try {
           await sdk.actions.addFrame();
         } catch (error) {


### PR DESCRIPTION
## Summary
- only call `sdk.actions.addFrame()` when `options.autoAddFrame` is true in `useFarcasterContext`

## Testing
- `yarn lint` *(fails: package not present)*

------
https://chatgpt.com/codex/tasks/task_e_6849b65e20a483319d254559c1b6eae0