### PR TITLE
Fix AppInit placement

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import { Inter } from 'next/font/google';
 import { Providers } from './providers';
 import { Toaster } from '@/components/ui/sonner';
+import { AppInit } from './components/app-init';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -47,7 +48,10 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${inter.variable} dark`}>
       <body className="antialiased bg-black text-white">
-        <Providers>{children}</Providers>
+        <Providers>
+          <AppInit />
+          {children}
+        </Providers>
         <Toaster theme="dark" />
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,9 @@
 import { Header } from './components/header';
 import { CoinsList } from './components/coins-list';
-import { AppInit } from './components/app-init';
 
 export default function Page() {
   return (
     <div className="max-w-lg mx-auto min-h-screen flex flex-col bg-gradient-to-b from-black via-zinc-900 to-black text-white">
-      <AppInit />
       <Header />
       <CoinsList />
     </div>


### PR DESCRIPTION
## Summary
- move `AppInit` into the global layout
- remove duplicate `AppInit` from the home page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b65f8b0c8331a58c13938a12e4eb