### PR TITLE
Fix Farcaster frame prompt in coin info page

### DIFF
--- a/app/components/info.tsx
+++ b/app/components/info.tsx
@@ -47,7 +47,7 @@ export function Info({
   onPlay,
   coinId,
 }: InfoProps) {
-  const { isReady } = useFarcasterContext();
+  const { isReady } = useFarcasterContext({ autoAddFrame: true });
   const { playStatus, isLoading, error, checkPlayStatus, recordPlay } =
     usePlayStatus();
   const { playerStats, isLoading: isLoadingStats } = usePlayerStats();


### PR DESCRIPTION
## Summary
- automatically prompt users to add the Farcaster frame when visiting coin info

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b66131b483318da06a8aad686b31