### PR TITLE
Use dynamic score in award API

### DIFF
--- a/app/api/award/route.ts
+++ b/app/api/award/route.ts
@@ -26,9 +26,9 @@ export async function POST(request: Request) {
   try {
     const { fid, coinId, score } = await request.json();
 
-    if (!fid || !coinId || typeof score !== 'number') {
+    if (!fid || !coinId || typeof score !== 'number' || score <= 0) {
       return NextResponse.json(
-        { error: 'Missing required fields' },
+        { error: 'Missing required fields or invalid score' },
         { status: 400, headers }
       );
     }
@@ -53,7 +53,7 @@ export async function POST(request: Request) {
       {
         fid,
         coin_id: coinId,
-        score: 1,
+        score,
       },
     ]);
 
@@ -67,7 +67,7 @@ export async function POST(request: Request) {
 
     // Then, increment the player's points
     try {
-      await supabaseService.incrementPlayerPoints(Number(fid), 1);
+      await supabaseService.incrementPlayerPoints(Number(fid), score);
     } catch (error) {
       console.error('Error updating points:', error);
       return NextResponse.json(


### PR DESCRIPTION
## Summary
- insert provided score when saving to the `scores` table
- increment player points by the same score value
- validate that the score is a positive number

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dc29bc8883319efb74663585b1d1