### PR TITLE
Implement minimum token requirement and purchase amount input

### DIFF
--- a/app/api/check-play-status/route.ts
+++ b/app/api/check-play-status/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseService } from '@/lib/supabase';
-import { Address, createPublicClient, http } from 'viem';
+import { Address, createPublicClient, http, parseEther } from 'viem';
 import { base } from 'viem/chains';
 
 // Create a public client for reading blockchain data
@@ -18,6 +18,8 @@ const ERC20_ABI = [
     outputs: [{ name: 'balance', type: 'uint256' }],
   },
 ] as const;
+
+const MIN_TOKENS = parseEther('0.001');
 
 export async function POST(request: NextRequest) {
   try {
@@ -68,7 +70,7 @@ export async function POST(request: NextRequest) {
         args: [walletAddress as Address],
       });
 
-      const hasTokens = balance > BigInt(0);
+      const hasTokens = balance >= MIN_TOKENS;
 
       return NextResponse.json({
         canPlay: hasTokens,

--- a/app/components/BuyCoinButton.tsx
+++ b/app/components/BuyCoinButton.tsx
@@ -19,7 +19,7 @@ interface BuyCoinButtonProps {
 
 export function BuyCoinButton({
   coinAddress,
-  amount = '0.0005',
+  amount = '0.001',
   symbol,
   onSuccess,
 }: BuyCoinButtonProps) {

--- a/app/components/game.tsx
+++ b/app/components/game.tsx
@@ -6,7 +6,7 @@ import { sdk } from '@farcaster/frame-sdk';
 import { BuyCoinButton } from './BuyCoinButton';
 import { useAccount, useConnect } from 'wagmi';
 import { useFarcasterContext } from '@/hooks/useFarcasterContext';
-import { Address, createPublicClient, http } from 'viem';
+import { Address, createPublicClient, http, parseEther } from 'viem';
 import { base } from 'viem/chains';
 
 // Create a public client for reading blockchain data
@@ -24,6 +24,8 @@ const ERC20_ABI = [
     outputs: [{ name: 'balance', type: 'uint256' }],
   },
 ] as const;
+
+const MIN_TOKENS = parseEther('0.001');
 
 interface GameProps {
   id: string;
@@ -47,6 +49,7 @@ export function Game({
   const [hasPlayedBefore, setHasPlayedBefore] = useState(false);
   const [checkingPlayStatus, setCheckingPlayStatus] = useState(true);
   const [roundScore, setRoundScore] = useState<number | null>(null);
+  const [buyAmount, setBuyAmount] = useState('0.001');
   const { context, isReady } = useFarcasterContext({
     disableNativeGestures: true,
   });
@@ -129,7 +132,7 @@ export function Game({
           args: [address as Address],
         });
 
-        const tokenBalance = balance > BigInt(0);
+        const tokenBalance = balance >= MIN_TOKENS;
         setHasTokens(tokenBalance);
       } catch (error) {
         console.error('Error checking token balance:', error);
@@ -234,7 +237,8 @@ export function Game({
                 🎉 Thanks for trying the game!
               </p>
               <p className="text-sm text-amber-400 mb-4">
-                Want unlimited access? Get tokens to play without time limits!
+                Want unlimited access? Buy at least 0.001 tokens to play without
+                time limits!
               </p>
               {!isConnected ? (
                 <button
@@ -244,16 +248,27 @@ export function Game({
                   Connect Wallet
                 </button>
               ) : (
-                <BuyCoinButton
-                  coinAddress={coinAddress}
-                  symbol=""
-                  onSuccess={() => {
-                    // Recheck both play status and token balance after purchase
-                    setCheckingTokens(true);
-                    setCheckingPlayStatus(true);
-                    setIsGameOver(false);
-                  }}
-                />
+                <div className="flex flex-col gap-2">
+                  <input
+                    type="number"
+                    step="0.001"
+                    min="0.001"
+                    value={buyAmount}
+                    onChange={(e) => setBuyAmount(e.target.value)}
+                    className="w-full px-3 py-2 rounded-md text-black"
+                  />
+                  <BuyCoinButton
+                    coinAddress={coinAddress}
+                    amount={buyAmount}
+                    symbol=""
+                    onSuccess={() => {
+                      // Recheck both play status and token balance after purchase
+                      setCheckingTokens(true);
+                      setCheckingPlayStatus(true);
+                      setIsGameOver(false);
+                    }}
+                  />
+                </div>
               )}
             </div>
           ) : hasTokens ? (
@@ -273,7 +288,7 @@ export function Game({
             // Returning player without tokens - needs to buy
             <div className="space-y-4">
               <p className="text-sm text-amber-400 mb-4">
-                You need tokens to continue playing this game.
+                You need at least 0.001 tokens to continue playing this game.
               </p>
               {!isConnected ? (
                 <button
@@ -283,15 +298,26 @@ export function Game({
                   Connect Wallet
                 </button>
               ) : (
-                <BuyCoinButton
-                  coinAddress={coinAddress}
-                  symbol=""
-                  onSuccess={() => {
-                    // Recheck token balance after purchase
-                    setCheckingTokens(true);
-                    setIsGameOver(false);
-                  }}
-                />
+                <div className="flex flex-col gap-2">
+                  <input
+                    type="number"
+                    step="0.001"
+                    min="0.001"
+                    value={buyAmount}
+                    onChange={(e) => setBuyAmount(e.target.value)}
+                    className="w-full px-3 py-2 rounded-md text-black"
+                  />
+                  <BuyCoinButton
+                    coinAddress={coinAddress}
+                    amount={buyAmount}
+                    symbol=""
+                    onSuccess={() => {
+                      // Recheck token balance after purchase
+                      setCheckingTokens(true);
+                      setIsGameOver(false);
+                    }}
+                  />
+                </div>
               )}
             </div>
           )}

--- a/app/components/info.tsx
+++ b/app/components/info.tsx
@@ -52,6 +52,7 @@ export function Info({
     usePlayStatus();
   const { playerStats, isLoading: isLoadingStats } = usePlayerStats();
   const [hasCheckedStatus, setHasCheckedStatus] = useState(false);
+  const [buyAmount, setBuyAmount] = useState('0.001');
   const { isConnected } = useAccount();
   const { connectors, connect } = useConnect();
 
@@ -241,7 +242,7 @@ export function Info({
                     Premium Access Required
                   </h3>
                   <p className="text-xs text-amber-300 mt-1">
-                    You need to own {symbol} tokens to play.
+                    You need at least 0.001 {symbol} tokens to play.
                   </p>
                 </div>
               </div>
@@ -317,13 +318,24 @@ export function Info({
                 Connect Wallet
               </button>
             ) : (
-              <BuyCoinButton
-                coinAddress={coinAddress}
-                symbol={symbol}
-                onSuccess={() => {
-                  setHasCheckedStatus(false);
-                }}
-              />
+              <div className="flex flex-col gap-2">
+                <input
+                  type="number"
+                  step="0.001"
+                  min="0.001"
+                  value={buyAmount}
+                  onChange={(e) => setBuyAmount(e.target.value)}
+                  className="w-full px-3 py-2 rounded-md text-black"
+                />
+                <BuyCoinButton
+                  coinAddress={coinAddress}
+                  amount={buyAmount}
+                  symbol={symbol}
+                  onSuccess={() => {
+                    setHasCheckedStatus(false);
+                  }}
+                />
+              </div>
             )}
           </div>
 


### PR DESCRIPTION
## Summary
- enforce `MIN_TOKENS` threshold in play status API and game component
- update BuyCoinButton default to 0.001
- add amount input field in info and game screens
- update UI text to mention 0.001 token minimum

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e2725a508331a742add46543fea9