### PR TITLE
Add Info page to navigation

### DIFF
--- a/app/components/header-profile.tsx
+++ b/app/components/header-profile.tsx
@@ -9,7 +9,15 @@ import {
 } from '@/app/components/ui/drawer';
 import { Button } from '@/app/components/ui/button';
 import Image from 'next/image';
-import { List, Trophy, Wallet, Copy, Sparkles, Share2 } from 'lucide-react';
+import {
+  List,
+  Trophy,
+  Wallet,
+  Copy,
+  Sparkles,
+  Share2,
+  Info as InfoIcon,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useFarcasterContext } from '@/hooks/useFarcasterContext';
 import { toast } from 'sonner';
@@ -142,6 +150,21 @@ export function HeaderProfile() {
     }
   };
 
+  const handleInfoNavigation = () => {
+    try {
+      trackGameEvent.navigationClick('info', 'header_profile');
+    } catch (error) {
+      sentryTracker.userActionError(
+        error instanceof Error ? error : new Error('Failed to track navigation'),
+        {
+          action: 'navigate_info',
+          element: 'navigation_link',
+          page: 'header_profile',
+        }
+      );
+    }
+  };
+
   const handleShareReferral = async () => {
     if (!context?.user?.fid) return;
     try {
@@ -250,6 +273,15 @@ export function HeaderProfile() {
               >
                 <Trophy className="w-6 h-6" />
                 <span>Leaderboard</span>
+              </Link>
+
+              <Link
+                className="flex items-center gap-4 text-xl font-semibold text-white hover:brightness-110 transition-all duration-200 cursor-pointer"
+                href="/info"
+                onClick={handleInfoNavigation}
+              >
+                <InfoIcon className="w-6 h-6" />
+                <span>How It Works</span>
               </Link>
 
               <button

--- a/app/components/posthog-provider.tsx
+++ b/app/components/posthog-provider.tsx
@@ -49,6 +49,7 @@ export function PostHogProvider({ children }: PostHogProviderProps) {
 function getPageName(pathname: string): string {
   if (pathname === '/') return 'Home';
   if (pathname === '/leaderboard') return 'Leaderboard';
+  if (pathname === '/info') return 'Info';
   if (pathname.startsWith('/coins/')) return 'Game';
   if (pathname.startsWith('/info/')) return 'Game Info';
 

--- a/app/info/page.tsx
+++ b/app/info/page.tsx
@@ -1,0 +1,32 @@
+import { Header } from '@/app/components/header';
+
+export default function InfoPage() {
+  return (
+    <div className="max-w-lg mx-auto min-h-screen flex flex-col bg-gradient-to-b from-black via-zinc-900 to-black text-white">
+      <Header />
+      <div className="px-4 pt-20 pb-8 space-y-6">
+        <h1 className="text-xl font-bold text-white">How Mini Games Work</h1>
+        <p className="text-white/70">
+          Mini Games lets you play quick onchain games directly in Farcaster Frames.
+          Each game has its own token that can be earned or traded on Zora.
+        </p>
+        <h2 className="text-sm font-semibold text-white">Playing Games</h2>
+        <p className="text-white/70">
+          Choose a game from the list, play a round and submit your score. High scores
+          earn points and may unlock token rewards from the creator.
+        </p>
+        <h2 className="text-sm font-semibold text-white">Economics</h2>
+        <p className="text-white/70">
+          Every game deploys a Zora token. You can buy tokens directly from the game
+          page and they transfer to your connected wallet. Some games distribute
+          tokens based on your performance or leaderboard position.
+        </p>
+        <p className="text-white/70">
+          Tokens are tradeable like any other Zora ERC‑20 asset. Check each game
+          description for details on how its economy works and how many tokens are
+          awarded for playing.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create an `/info` page with details on gameplay and token economics
- expose the new page in the profile drawer navigation
- track visits through PostHog page naming

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f1b9093083318f29b0f3ad9d5b2d