### PR TITLE
Unify loading spinners

### DIFF
--- a/app/components/app-init.tsx
+++ b/app/components/app-init.tsx
@@ -5,6 +5,7 @@ import { useAccount } from 'wagmi';
 import { useFarcasterContext } from '@/hooks/useFarcasterContext';
 import { trackGameEvent, identifyUser, setUserProperties } from '@/lib/posthog';
 import { setSentryUser, sentryTracker } from '@/lib/sentry';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
 
 export function AppInit() {
   const { context, isReady } = useFarcasterContext({ autoAddFrame: true });
@@ -162,7 +163,7 @@ export function AppInit() {
     return (
       <div className="fixed inset-0 z-50 bg-black flex items-center justify-center">
         <div className="flex flex-col items-center space-y-4">
-          <div className="animate-spin rounded-full h-12 w-12 border-2 border-gray-600 border-t-purple-500"></div>
+          <LoadingSpinner />
           <div className="text-white/70">Loading...</div>
         </div>
       </div>

--- a/app/components/coin-leaderboard.tsx
+++ b/app/components/coin-leaderboard.tsx
@@ -4,6 +4,7 @@ import { useCoinLeaderboard } from '@/hooks/useCoinLeaderboard';
 import { useFarcasterContext } from '@/hooks/useFarcasterContext';
 import { Trophy, Medal, Crown, Share2 } from 'lucide-react';
 import { sdk } from '@farcaster/frame-sdk';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
 
 interface CoinLeaderboardProps {
   coinId: string;
@@ -79,7 +80,7 @@ export function CoinLeaderboard({
     return (
       <div className="p-6 border-t border-gray-700">
         <div className="flex items-center justify-center py-8">
-          <div className="animate-spin rounded-full h-8 w-8 border-2 border-gray-600 border-t-purple-400"></div>
+          <LoadingSpinner className="h-8 w-8" />
         </div>
       </div>
     );

--- a/app/components/game-wrapper.tsx
+++ b/app/components/game-wrapper.tsx
@@ -11,6 +11,7 @@ import { ArrowLeft, Clock } from 'lucide-react';
 import { Button } from './ui/button';
 import { trackGameEvent, trackEvent } from '@/lib/posthog';
 import { sentryTracker, setSentryTags } from '@/lib/sentry';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
 
 interface GameWrapperProps {
   id: string;
@@ -318,7 +319,7 @@ export function GameWrapper({
     return (
       <div className="min-h-screen bg-black flex items-center justify-center">
         <div className="flex flex-col items-center space-y-4">
-          <div className="animate-spin rounded-full h-12 w-12 border-2 border-gray-600 border-t-purple-500"></div>
+          <LoadingSpinner />
           <div className="text-white/70">Loading...</div>
         </div>
       </div>

--- a/app/components/game.tsx
+++ b/app/components/game.tsx
@@ -6,6 +6,7 @@ import { useAccount } from 'wagmi';
 import { useFarcasterContext } from '@/hooks/useFarcasterContext';
 import { Address, createPublicClient, http } from 'viem';
 import { base } from 'viem/chains';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
 
 // Create a public client for reading blockchain data
 const publicClient = createPublicClient({
@@ -245,7 +246,7 @@ export function Game({
     return (
       <div className="min-h-screen bg-black flex items-center justify-center">
         <div className="flex flex-col items-center space-y-4">
-          <div className="animate-spin rounded-full h-12 w-12 border-2 border-gray-600 border-t-purple-500"></div>
+          <LoadingSpinner />
           <div className="text-white/70">Loading...</div>
         </div>
       </div>
@@ -262,7 +263,7 @@ export function Game({
       {loading && (
         <div className="absolute inset-0 flex items-center justify-center bg-black">
           <div className="flex flex-col items-center space-y-4">
-            <div className="animate-spin rounded-full h-12 w-12 border-2 border-gray-600 border-t-purple-500"></div>
+            <LoadingSpinner />
             <p className="text-white/70">Loading game...</p>
           </div>
         </div>

--- a/app/components/info.tsx
+++ b/app/components/info.tsx
@@ -21,6 +21,7 @@ import { formatCurrency, formatHolders, formatTokenBalance } from '@/lib/utils';
 import { sdk } from '@farcaster/frame-sdk';
 import { Header } from './header';
 import { CoinLeaderboard } from './coin-leaderboard';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
 
 // Create a public client for reading blockchain data
 const publicClient = createPublicClient({
@@ -206,7 +207,7 @@ export function Info({
       <div className="min-h-screen bg-black flex items-center justify-center p-4">
         <div className="bg-black/20 backdrop-blur rounded-2xl shadow-xl p-8 text-center max-w-md border border-white/20">
           <div className="flex flex-col items-center space-y-4">
-            <div className="animate-spin rounded-full h-8 w-8 border-2 border-gray-600 border-t-blue-400"></div>
+            <LoadingSpinner className="h-8 w-8" />
             <div className="text-white/70">Loading...</div>
           </div>
         </div>

--- a/components/ui/loading-spinner.tsx
+++ b/components/ui/loading-spinner.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+interface LoadingSpinnerProps {
+  className?: string
+}
+
+export function LoadingSpinner({ className }: LoadingSpinnerProps) {
+  return (
+    <div
+      className={cn(
+        'animate-spin rounded-full h-12 w-12 border-2 border-gray-600 border-t-purple-500',
+        className,
+      )}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- add LoadingSpinner component
- use LoadingSpinner across the app so all loading screens match

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a25263c748331ac2afdd398f01188