### PR TITLE
Implement daily free play cooldown

### DIFF
--- a/app/components/info.tsx
+++ b/app/components/info.tsx
@@ -58,6 +58,15 @@ export function Info({
   const { isConnected } = useAccount();
   const { connectors, connect } = useConnect();
 
+  const formatNextFreePlay = () => {
+    if (!playStatus?.nextFreePlay) return null;
+    const diff = new Date(playStatus.nextFreePlay).getTime() - Date.now();
+    if (diff <= 0) return 'now';
+    const hours = Math.floor(diff / 3600000);
+    const minutes = Math.floor((diff % 3600000) / 60000);
+    return `in ${hours}h ${minutes}m`;
+  };
+
   // Validate and sanitize buy amount input
   const handleBuyAmountChange = (value: string) => {
     // Allow empty string temporarily for user input
@@ -103,10 +112,8 @@ export function Info({
     if (!playStatus) return;
 
     if (playStatus.canPlay) {
-      // Record the play if they haven't played before
-      if (!playStatus.hasPlayed) {
-        await recordPlay(id, coinAddress);
-      }
+      // Record the play to update last played timestamp
+      await recordPlay(id, coinAddress);
       onPlay();
     }
   };
@@ -281,6 +288,11 @@ export function Info({
                     You need at least {PREMIUM_THRESHOLD.toLocaleString()}{' '}
                     {symbol} tokens to play.
                   </p>
+                  {playStatus.nextFreePlay && (
+                    <p className="text-xs text-amber-300 mt-1">
+                      Next free play available {formatNextFreePlay()}.
+                    </p>
+                  )}
                 </div>
               </div>
             </div>
@@ -521,10 +533,10 @@ export function Info({
               </div>
               <div>
                 <h3 className="text-sm font-semibold text-green-200">
-                  Free Trial Available
+                  Daily Free Play
                 </h3>
                 <p className="text-xs text-green-300 mt-1">
-                  Play for free on your first attempt!
+                  Your first play each day is free!
                 </p>
               </div>
             </div>

--- a/hooks/usePlayStatus.ts
+++ b/hooks/usePlayStatus.ts
@@ -12,6 +12,7 @@ export type PlayStatus = {
     | 'balance_check_failed';
   hasPlayed: boolean;
   tokenBalance: string;
+  nextFreePlay?: string | null;
 };
 
 export function usePlayStatus() {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -26,6 +26,15 @@ export const PREMIUM_THRESHOLD = parseInt(
 );
 
 /**
+ * Free play interval in seconds. Players can play for free once within this
+ * period. Defaults to 86400 seconds (24 hours)
+ */
+export const FREE_PLAY_INTERVAL = parseInt(
+  process.env.NEXT_PUBLIC_FREE_PLAY_INTERVAL ?? '86400',
+  10
+);
+
+/**
  * Validate that the token multiplier is a positive number
  */
 if (isNaN(TOKEN_MULTIPLIER) || TOKEN_MULTIPLIER <= 0) {
@@ -40,5 +49,14 @@ if (isNaN(TOKEN_MULTIPLIER) || TOKEN_MULTIPLIER <= 0) {
 if (isNaN(PREMIUM_THRESHOLD) || PREMIUM_THRESHOLD <= 0) {
   throw new Error(
     'PREMIUM_THRESHOLD must be a positive number. Check NEXT_PUBLIC_PREMIUM_THRESHOLD environment variable.'
+  );
+}
+
+/**
+ * Validate that the free play interval is a positive number
+ */
+if (isNaN(FREE_PLAY_INTERVAL) || FREE_PLAY_INTERVAL <= 0) {
+  throw new Error(
+    'FREE_PLAY_INTERVAL must be a positive number. Check NEXT_PUBLIC_FREE_PLAY_INTERVAL environment variable.'
   );
 }


### PR DESCRIPTION
## Summary
- add FREE_PLAY_INTERVAL config constant
- track last play times in Supabase and expose via `getGamePlay`
- update `check-play-status` API for daily free play with next free time
- show daily free play info in the UI and display next free time
- adjust `PlayStatus` type and always record game plays

## Testing
- `yarn lint` *(fails: package not present)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850199c609c83318a08d38d4dd03273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a daily free play system, allowing users one free play every 24 hours.
	- The interface now displays when your next free play will be available.
- **Improvements**
	- Enhanced messaging to clarify free play availability and timing.
	- Updated labels and descriptions for the free play feature to improve clarity.
- **Bug Fixes**
	- Improved accuracy in determining and displaying free play eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->