### PR TITLE
Check premium token balance for play

### DIFF
--- a/app/components/info.tsx
+++ b/app/components/info.tsx
@@ -503,7 +503,8 @@ export function Info({
         )}
 
         {/* Status indicators */}
-        {(!playStatus.hasPlayed || playStatus.reason === 'daily_free') && (
+        {(playStatus.reason === 'first_time' ||
+          playStatus.reason === 'daily_free') && (
           <div className="p-6 bg-green-900/30 border-b border-green-700/30">
             <div className="flex items-start space-x-3">
               <div className="w-6 h-6 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
@@ -533,7 +534,7 @@ export function Info({
           </div>
         )}
 
-        {playStatus.hasPlayed && playStatus.reason === 'has_tokens' && (
+        {playStatus.reason === 'has_tokens' && (
           <div className="p-6 bg-blue-900/30 border-b border-blue-700/30">
             <div className="flex items-start space-x-3">
               <div className="w-6 h-6 rounded-full bg-blue-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">


### PR DESCRIPTION
## Summary
- check token balance when a free play is requested
- show premium section regardless of previous play
- show free trial message only for first-time or daily-free plays

## Testing
- `npx --yes next lint` *(fails: 403 Forbidden)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68526d58b4a08331ad42d7bdb882f321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for determining play eligibility and token balance checks, resulting in more accurate and consistent responses.
- **Style**
  - Simplified and clarified the display of status indicators for free trial and premium player statuses, making them more intuitive for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->