### PR TITLE
Fix reload on first game start

### DIFF
--- a/app/components/info.tsx
+++ b/app/components/info.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useFarcasterContext } from '@/hooks/useFarcasterContext';
 import { usePlayStatus } from '@/hooks/usePlayStatus';
 import { useAccount, useConnect } from 'wagmi';
@@ -62,7 +62,10 @@ export function Info({
     });
   };
 
-  const handlePlay = async () => {
+  const handlePlay = async (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    e.preventDefault();
     if (isStartingGame) return; // Prevent multiple clicks
 
     console.log('🎮 Info: Starting game...');
@@ -478,6 +481,7 @@ export function Info({
               {description}
             </p>
             <button
+              type="button"
               onClick={handlePlay}
               disabled={isStartingGame}
               className="w-full bg-purple-600 text-white px-4 py-4 rounded-full font-semibold shadow-xl shadow-purple-500/20 hover:brightness-110 transition-all duration-200 text-lg disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
## Summary
- prevent default button action when starting a game
- explicitly set the play button type to avoid implicit form submission
- update React import

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `yarn install` *(fails: RequestError: Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_6852dcd699288331b61ea4973663e034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved play button behavior to prevent unintended default actions when clicked.
  - Enhanced event handling for a smoother user experience when initiating playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->