### PR TITLE
Handle Farcaster init failure

### DIFF
--- a/hooks/useFarcasterContext.ts
+++ b/hooks/useFarcasterContext.ts
@@ -32,6 +32,17 @@ export function useFarcasterContext(options: UseFarcasterContextOptions = {}) {
         setIsReady(true);
       } catch (error) {
         console.error('Failed to initialize frame:', error);
+        try {
+          await sdk.actions.ready({
+            disableNativeGestures: options.disableNativeGestures,
+          });
+        } catch (readyError) {
+          console.error(
+            'Failed to signal ready after init failure:',
+            readyError
+          );
+        }
+        setIsReady(true);
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
## Summary
- call `sdk.actions.ready` even when initialization fails
- set `isReady` on error so the loader unblocks

## Testing
- `npx prettier -w hooks/useFarcasterContext.ts`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852eca8247c8331b10a33438c807449