### PR TITLE
Handle Farcaster init failure

### DIFF
--- a/app/components/app-init.tsx
+++ b/app/components/app-init.tsx
@@ -14,7 +14,7 @@ import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { sdk } from '@farcaster/frame-sdk';
 
 export function AppInit() {
-  const { context, isReady } = useFarcasterContext({ autoAddFrame: true });
+  const { context, isReady } = useFarcasterContext();
   const { address } = useAccount();
 
   // Avoid triggering the saveUser routine multiple times which can lead to 429 errors

--- a/app/components/game.tsx
+++ b/app/components/game.tsx
@@ -59,9 +59,7 @@ export function Game({
   const [checkingTokens, setCheckingTokens] = useState(true);
   const [roundScore, setRoundScore] = useState<number | null>(null);
   const [tokenDecimals, setTokenDecimals] = useState<number>(18); // Default to 18, will be fetched
-  const { context, isReady } = useFarcasterContext({
-    disableNativeGestures: true,
-  });
+  const { context, isReady } = useFarcasterContext();
   const { address, isConnected } = useAccount();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,6 +6,7 @@ import { base } from 'wagmi/chains';
 import { farcasterFrame } from '@farcaster/frame-wagmi-connector';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PostHogProvider } from './components/posthog-provider';
+import { FarcasterProvider } from '@/hooks/useFarcasterContext';
 
 const config = createConfig({
   chains: [base],
@@ -22,7 +23,9 @@ export function Providers(props: { children: ReactNode }) {
     <PostHogProvider>
       <WagmiProvider config={config}>
         <QueryClientProvider client={queryClient}>
-          {props.children}
+          <FarcasterProvider autoAddFrame disableNativeGestures>
+            {props.children}
+          </FarcasterProvider>
         </QueryClientProvider>
       </WagmiProvider>
     </PostHogProvider>


### PR DESCRIPTION
## Summary
- call `sdk.actions.ready` even when initialization fails
- set `isReady` on error so the loader unblocks
- centralize Farcaster initialization with a provider to avoid multiple conflicting calls

## Testing
- `npx prettier -w hooks/useFarcasterContext.tsx app/providers.tsx app/components/app-init.tsx app/components/game.tsx`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852eca8247c8331b10a33438c807449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Farcaster integration with a new provider-based architecture, enhancing state management and error handling.
- **Refactor**
  - Updated how Farcaster context is initialized and consumed across the app for better reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->