### PR TITLE
Implement daily login streaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,15 @@ To get started building your own frame, follow these steps:
 - [OnchainKit Documentation](https://docs.base.org/builderkits/onchainkit/getting-started)
 - [Next.js Documentation](https://nextjs.org/docs)
 - [Tailwind CSS Documentation](https://tailwindcss.com/docs)
+
+## Supabase Setup
+
+Add a `daily_streaks` table to track consecutive logins.
+
+| Column       | Type    | Notes                                  |
+| ------------ | ------- | -------------------------------------- |
+| `fid`        | int     | Primary key, references `players.fid`  |
+| `streak`     | int     | Current streak count                   |
+| `last_login` | date    | Date of the most recent login          |
+| `last_claimed` | date  | Date when the reward was claimed       |
+

--- a/app/api/auth/sign-in/route.ts
+++ b/app/api/auth/sign-in/route.ts
@@ -51,7 +51,14 @@ export const POST = async (req: NextRequest) => {
     wallet_address: walletAddress,
   });
 
-  const streak = await supabaseService.recordDailyLogin(fid);
+  let streak;
+  try {
+    streak = await supabaseService.recordDailyLogin(fid);
+  } catch (e) {
+    console.error('Error recording daily login streak:', e);
+    // Provide default streak value to ensure sign-in continues
+    streak = { current_streak: 0, longest_streak: 0, last_login: new Date() };
+  }
 
   // Generate JWT token
   const secret = new TextEncoder().encode(process.env.JWT_SECRET);

--- a/app/api/auth/sign-in/route.ts
+++ b/app/api/auth/sign-in/route.ts
@@ -51,6 +51,8 @@ export const POST = async (req: NextRequest) => {
     wallet_address: walletAddress,
   });
 
+  const streak = await supabaseService.recordDailyLogin(fid);
+
   // Generate JWT token
   const secret = new TextEncoder().encode(process.env.JWT_SECRET);
   const token = await new jose.SignJWT({
@@ -64,7 +66,7 @@ export const POST = async (req: NextRequest) => {
     .sign(secret);
 
   // Create the response
-  const response = NextResponse.json({ success: true, user });
+  const response = NextResponse.json({ success: true, user, streak });
 
   // Set the auth cookie with the JWT token
   response.cookies.set({

--- a/app/api/auth/sign-in/route.ts
+++ b/app/api/auth/sign-in/route.ts
@@ -57,7 +57,7 @@ export const POST = async (req: NextRequest) => {
   } catch (e) {
     console.error('Error recording daily login streak:', e);
     // Provide default streak value to ensure sign-in continues
-    streak = { current_streak: 0, longest_streak: 0, last_login: new Date() };
+    streak = { streak: 0, claimed: false };
   }
 
   // Generate JWT token

--- a/app/api/auth/sign-in/route.ts
+++ b/app/api/auth/sign-in/route.ts
@@ -57,7 +57,7 @@ export const POST = async (req: NextRequest) => {
   } catch (e) {
     console.error('Error recording daily login streak:', e);
     // Provide default streak value to ensure sign-in continues
-    streak = { streak: 0, claimed: false };
+    streak = { streak: 1, claimed: false };
   }
 
   // Generate JWT token

--- a/app/api/daily-streak/route.ts
+++ b/app/api/daily-streak/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
   }
   try {
     const streak = await supabaseService.getDailyStreak(fid);
-    return NextResponse.json(streak || { streak: 0, claimed: false });
+    return NextResponse.json(streak || { streak: 1, claimed: false });
   } catch (error) {
     console.error('Error getting daily streak:', error);
     return NextResponse.json(

--- a/app/api/daily-streak/route.ts
+++ b/app/api/daily-streak/route.ts
@@ -7,12 +7,18 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   const fid = parseInt(fidHeader);
+  if (isNaN(fid)) {
+    return NextResponse.json({ error: 'Invalid user ID' }, { status: 400 });
+  }
   try {
     const streak = await supabaseService.getDailyStreak(fid);
     return NextResponse.json(streak || { streak: 0, claimed: false });
   } catch (error) {
     console.error('Error getting daily streak:', error);
-    return NextResponse.json({ error: 'Failed to get streak' }, { status: 500 });
+    return NextResponse.json(
+      { error: 'Failed to get streak' },
+      { status: 500 }
+    );
   }
 }
 
@@ -22,12 +28,18 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   const fid = parseInt(fidHeader);
+  if (isNaN(fid)) {
+    return NextResponse.json({ error: 'Invalid user ID' }, { status: 400 });
+  }
   try {
     const streak = await supabaseService.recordDailyLogin(fid);
     return NextResponse.json(streak);
   } catch (error) {
     console.error('Error recording daily login:', error);
-    return NextResponse.json({ error: 'Failed to record login' }, { status: 500 });
+    return NextResponse.json(
+      { error: 'Failed to record login' },
+      { status: 500 }
+    );
   }
 }
 
@@ -37,11 +49,17 @@ export async function PUT(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   const fid = parseInt(fidHeader);
+  if (isNaN(fid)) {
+    return NextResponse.json({ error: 'Invalid user ID' }, { status: 400 });
+  }
   try {
     const streak = await supabaseService.claimDailyStreak(fid);
     return NextResponse.json(streak);
   } catch (error) {
     console.error('Error claiming daily streak:', error);
-    return NextResponse.json({ error: 'Failed to claim streak' }, { status: 500 });
+    return NextResponse.json(
+      { error: 'Failed to claim streak' },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/daily-streak/route.ts
+++ b/app/api/daily-streak/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseService } from '@/lib/supabase';
+
+export async function GET(request: NextRequest) {
+  const fidHeader = request.headers.get('x-user-fid');
+  if (!fidHeader) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const fid = parseInt(fidHeader);
+  try {
+    const streak = await supabaseService.getDailyStreak(fid);
+    return NextResponse.json(streak || { streak: 0, claimed: false });
+  } catch (error) {
+    console.error('Error getting daily streak:', error);
+    return NextResponse.json({ error: 'Failed to get streak' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const fidHeader = request.headers.get('x-user-fid');
+  if (!fidHeader) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const fid = parseInt(fidHeader);
+  try {
+    const streak = await supabaseService.recordDailyLogin(fid);
+    return NextResponse.json(streak);
+  } catch (error) {
+    console.error('Error recording daily login:', error);
+    return NextResponse.json({ error: 'Failed to record login' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const fidHeader = request.headers.get('x-user-fid');
+  if (!fidHeader) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const fid = parseInt(fidHeader);
+  try {
+    const streak = await supabaseService.claimDailyStreak(fid);
+    return NextResponse.json(streak);
+  } catch (error) {
+    console.error('Error claiming daily streak:', error);
+    return NextResponse.json({ error: 'Failed to claim streak' }, { status: 500 });
+  }
+}

--- a/app/coins/[id]/page.tsx
+++ b/app/coins/[id]/page.tsx
@@ -15,7 +15,6 @@ export async function generateMetadata({
 }: TokenPageProps): Promise<Metadata> {
   const { id } = await params;
   const coin = await supabaseService.getCoinById(id);
-  console.log('coin', coin);
 
   // Ensure all URLs are absolute for Farcaster frames
   const imageUrl = coin.image?.startsWith('http')

--- a/components/app-init.tsx
+++ b/components/app-init.tsx
@@ -49,6 +49,11 @@ export function AppInit({ children }: AppInitProps) {
           const data = await res.json();
           setStreak(data);
         } else {
+          console.error(
+            'Failed to fetch daily streak:',
+            res.status,
+            res.statusText
+          );
           // Set a default streak to prevent infinite loop
           setStreak({ streak: 0, claimed: true });
         }
@@ -106,7 +111,9 @@ export function AppInit({ children }: AppInitProps) {
         <DailyStreakDialog
           streak={streak.streak}
           onClaim={async () => {
-            if (!context?.user?.fid) {
+            const userFid = context?.user?.fid;
+
+            if (!userFid) {
               console.error('No user FID available for claiming streak');
               return;
             }
@@ -116,15 +123,16 @@ export function AppInit({ children }: AppInitProps) {
                 method: 'PUT',
                 headers: {
                   'Content-Type': 'application/json',
-                  'x-user-fid': context.user.fid.toString(),
+                  'x-user-fid': userFid.toString(),
                 },
               });
 
               if (!response.ok) {
-                const errorData = await response.json();
+                const errorData = await response.json().catch(() => ({}));
                 console.error(
                   'Failed to claim streak:',
                   response.status,
+                  response.statusText,
                   errorData
                 );
                 return;

--- a/components/app-init.tsx
+++ b/components/app-init.tsx
@@ -35,7 +35,7 @@ export function AppInit({ children }: AppInitProps) {
   useEffect(() => {
     const fetchStreak = async () => {
       if (!context?.user?.fid) {
-        setStreak({ streak: 0, claimed: true, fid: undefined });
+        setStreak({ streak: 1, claimed: true, fid: undefined });
         return;
       }
 
@@ -57,12 +57,12 @@ export function AppInit({ children }: AppInitProps) {
             res.statusText
           );
           // Set a default streak to prevent infinite loop
-          setStreak({ streak: 0, claimed: true, fid: context.user.fid });
+          setStreak({ streak: 1, claimed: true, fid: context.user.fid });
         }
       } catch (err) {
         console.error('Failed to fetch daily streak', err);
         // Set a default streak to prevent infinite loop
-        setStreak({ streak: 0, claimed: true, fid: context.user.fid });
+        setStreak({ streak: 1, claimed: true, fid: context.user.fid });
       }
     };
 

--- a/components/daily-streak-dialog.tsx
+++ b/components/daily-streak-dialog.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
-import confetti from 'canvas-confetti';
 import { Button } from './ui/button';
 
 interface DailyStreakDialogProps {
@@ -10,9 +8,6 @@ interface DailyStreakDialogProps {
 }
 
 export function DailyStreakDialog({ streak, onClaim }: DailyStreakDialogProps) {
-  useEffect(() => {
-    confetti({ particleCount: 100, spread: 70 });
-  }, []);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-md">

--- a/components/daily-streak-dialog.tsx
+++ b/components/daily-streak-dialog.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+import confetti from 'canvas-confetti';
+import { Button } from './ui/button';
+
+interface DailyStreakDialogProps {
+  streak: number;
+  onClaim: () => void;
+}
+
+export function DailyStreakDialog({ streak, onClaim }: DailyStreakDialogProps) {
+  useEffect(() => {
+    confetti({ particleCount: 100, spread: 70 });
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-md">
+      <div className="mx-4 w-full max-w-md space-y-6 rounded-3xl border border-white/20 bg-black/20 p-8 text-center shadow-2xl backdrop-blur-xl animate-in fade-in-0 zoom-in-95 duration-500">
+        <h1 className="text-3xl font-bold bg-gradient-to-r from-orange-400 to-yellow-400 bg-clip-text text-transparent">
+          {`Day ${streak} Streak!`}
+        </h1>
+        <Button onClick={onClaim} className="w-full rounded-full bg-purple-600 text-white hover:bg-purple-700">
+          Claim Streak
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/daily-streak-indicator.tsx
+++ b/components/daily-streak-indicator.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Flame } from 'lucide-react';
+import { sdk } from '@farcaster/frame-sdk';
+import { useDailyStreak } from '@/hooks/use-daily-streak';
+
+export function DailyStreakIndicator() {
+  const { data } = useDailyStreak(true);
+  const streak = data?.streak ?? 0;
+
+  const handleShare = async () => {
+    try {
+      await sdk.actions.composeCast({
+        text: `I'm on a ${streak}-day streak at Mini Games!`,
+        embeds: ['https://app.minigames.studio'],
+      });
+    } catch (error) {
+      console.error('Failed to share streak:', error);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleShare}
+      className="flex items-center gap-1 rounded-full bg-white/10 px-2 py-1 text-sm text-white hover:brightness-110 transition-all"
+    >
+      <Flame className="w-4 h-4 text-orange-400" />
+      <span>{streak}</span>
+    </button>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -4,6 +4,7 @@ import { Sparkles, Info as InfoIcon } from 'lucide-react';
 import Link from 'next/link';
 import { WelcomeDialog } from './welcome-dialog';
 import { trackGameEvent } from '@/lib/posthog';
+import { DailyStreakIndicator } from './daily-streak-indicator';
 
 export function Header() {
   const handleHomeClick = () => {
@@ -24,16 +25,19 @@ export function Header() {
         <Sparkles className="w-6 h-6 text-purple-400" />
       </Link>
 
-      <WelcomeDialog
-        trigger={
-          <button
-            className="flex items-center justify-center w-8 h-8 rounded-full bg-white/10 backdrop-blur border border-white/20 text-white hover:brightness-110 transition-all duration-200"
-            onClick={handleInfoNavigation}
-          >
-            <InfoIcon className="w-4 h-4" />
-          </button>
-        }
-      />
+      <div className="flex items-center gap-2">
+        <DailyStreakIndicator />
+        <WelcomeDialog
+          trigger={
+            <button
+              className="flex items-center justify-center w-8 h-8 rounded-full bg-white/10 backdrop-blur border border-white/20 text-white hover:brightness-110 transition-all duration-200"
+              onClick={handleInfoNavigation}
+            >
+              <InfoIcon className="w-4 h-4" />
+            </button>
+          }
+        />
+      </div>
     </header>
   );
 }

--- a/hooks/use-daily-streak.ts
+++ b/hooks/use-daily-streak.ts
@@ -1,0 +1,11 @@
+import { useApiQuery } from './use-api-query';
+
+export function useDailyStreak(enabled = true) {
+  return useApiQuery<{ streak: number; claimed: boolean }>({
+    url: '/api/daily-streak',
+    method: 'GET',
+    isProtected: true,
+    queryKey: ['daily-streak'],
+    enabled,
+  });
+}

--- a/hooks/usePlayStatus.ts
+++ b/hooks/usePlayStatus.ts
@@ -47,6 +47,8 @@ export function usePlayStatus() {
           }),
         });
 
+        console.log('response', response);
+
         if (!response.ok) {
           throw new Error('Failed to check play status');
         }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -647,28 +647,38 @@ export const supabaseService = {
     let newStreak = row.streak as number;
     const lastLogin = row.last_login as string | null;
 
+    // Always calculate streak properly, including when last_login is null
     if (lastLogin) {
       const diff =
         (new Date(today).getTime() - new Date(lastLogin).getTime()) /
         (1000 * 60 * 60 * 24);
-      if (diff >= 1 && diff < 2) newStreak = row.streak + 1;
-      else if (diff >= 2) newStreak = 1;
+      if (diff >= 1 && diff < 2) {
+        newStreak = row.streak + 1;
+      } else if (diff >= 2) {
+        newStreak = 1;
+      }
+      // If diff < 1 (same day), keep current streak
     } else {
       // Handle null last_login by resetting streak to 1
       newStreak = 1;
     }
 
-    const { error: updateError } = await supabase
+    const { data: updatedData, error: updateError } = await supabase
       .from('daily_streaks')
       .update({ streak: newStreak, last_login: today })
-      .eq('fid', fid);
+      .eq('fid', fid)
+      .select('streak, last_claimed')
+      .single();
 
     if (updateError) {
       console.error('Error updating daily streak:', updateError);
       throw new Error('Failed to record daily login');
     }
 
-    return { streak: newStreak, claimed: row?.last_claimed === today };
+    return {
+      streak: updatedData.streak as number,
+      claimed: updatedData.last_claimed === today,
+    };
   },
 
   async claimDailyStreak(fid: number) {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -687,15 +687,22 @@ export const supabaseService = {
       .from('daily_streaks')
       .update({ last_claimed: today })
       .eq('fid', fid)
-      .select('streak, last_claimed')
-      .single();
+      .select('streak, last_claimed');
 
     if (error) {
       console.error('Error claiming daily streak:', error);
       throw new Error('Failed to claim daily streak');
     }
 
-    return { streak: data.streak as number, claimed: true };
+    if (!data || data.length === 0) {
+      throw new Error('No daily streak record found');
+    }
+
+    // Handle multiple rows case by using the first one
+    // This shouldn't happen ideally, but we handle it gracefully
+    const streakData = Array.isArray(data) ? data[0] : data;
+
+    return { streak: streakData.streak as number, claimed: true };
   },
 
   // Add direct access to supabase client

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -653,12 +653,20 @@ export const supabaseService = {
         (1000 * 60 * 60 * 24);
       if (diff >= 1 && diff < 2) newStreak = row.streak + 1;
       else if (diff >= 2) newStreak = 1;
+    } else {
+      // Handle null last_login by resetting streak to 1
+      newStreak = 1;
     }
 
-    await supabase
+    const { error: updateError } = await supabase
       .from('daily_streaks')
       .update({ streak: newStreak, last_login: today })
       .eq('fid', fid);
+
+    if (updateError) {
+      console.error('Error updating daily streak:', updateError);
+      throw new Error('Failed to record daily login');
+    }
 
     return { streak: newStreak, claimed: row?.last_claimed === today };
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "sonner": "^2.0.4",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
-    "canvas-confetti": "^1.9.1",
     "vaul": "^1.1.2",
     "viem": "^2.23.14",
     "wagmi": "^2.14.11"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "sonner": "^2.0.4",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
+    "canvas-confetti": "^1.9.1",
     "vaul": "^1.1.2",
     "viem": "^2.23.14",
     "wagmi": "^2.14.11"


### PR DESCRIPTION
## Summary
- add Supabase table description for daily streaks
- track daily streak on sign-in and expose endpoint
- provide daily streak dialog and indicator
- show streak in header next to info button
- add canvas-confetti

## Testing
- `yarn install --frozen-lockfile` *(fails: RequestError: Bad response: 403)*
- `npx eslint components/app-init.tsx components/header.tsx components/daily-streak-dialog.tsx components/daily-streak-indicator.tsx hooks/use-daily-streak.ts app/api/daily-streak/route.ts app/api/auth/sign-in/route.ts lib/supabase.ts` *(fails: ESLint couldn't find a config file)*
- `npx tsc -p tsconfig.json` *(fails with numerous module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c53803ac083319873f2504aac6a0a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a daily streak system that tracks and displays consecutive user logins.
  - Added a modal dialog allowing users to claim their daily streak reward.
  - Added a daily streak indicator in the header, enabling users to view and share their streak.
- **Documentation**
  - Updated instructions to include Supabase setup for daily streak tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->