### PR TITLE
Ensure JWT expiration is fixed at 7 days

### DIFF
--- a/app/api/auth/sign-in/route.ts
+++ b/app/api/auth/sign-in/route.ts
@@ -26,7 +26,6 @@ export const POST = async (req: NextRequest) => {
     fid = Number(payload.sub);
     walletAddress = payload.address as Address;
     console.log('walletAddress', walletAddress);
-    expirationTime = payload.exp ?? Date.now() + 7 * 24 * 60 * 60 * 1000;
   } catch (e) {
     if (e instanceof Errors.InvalidTokenError) {
       console.error('Invalid token', e);


### PR DESCRIPTION
## Summary
- remove resetting `expirationTime` from decoded payload
- keep JWT validity aligned with cookie `maxAge`

## Testing
- `node` script to sign and decode a JWT shows `exp` roughly 168 hours in the future

------
https://chatgpt.com/codex/tasks/task_e_685d49705af0833190b7d0df84cae56a