### PR TITLE
Handle coin fetch errors gracefully

### DIFF
--- a/components/coins-list.tsx
+++ b/components/coins-list.tsx
@@ -5,25 +5,33 @@ import { CoinCard } from './coin-card';
 
 const getCoinsWithData = unstable_cache(
   async () => {
-    const coins: Coin[] = await supabaseService.getCoins();
-    const coinsWithCreators: CoinWithCreator[] = await Promise.all(
-      coins.map(async (coin) => {
-        try {
-          const creator = await supabaseService.getCreatorByFID(coin.fid);
-          return {
-            ...coin,
-            creator: creator[0] || undefined,
-          } as CoinWithCreator;
-        } catch (error) {
-          console.error(`Failed to fetch creator for coin ${coin.fid}:`, error);
-          return {
-            ...coin,
-            creator: undefined,
-          } as CoinWithCreator;
-        }
-      })
-    );
-    return coinsWithCreators;
+    try {
+      const coins: Coin[] = await supabaseService.getCoins();
+      const coinsWithCreators: CoinWithCreator[] = await Promise.all(
+        coins.map(async (coin) => {
+          try {
+            const creator = await supabaseService.getCreatorByFID(coin.fid);
+            return {
+              ...coin,
+              creator: creator[0] || undefined,
+            } as CoinWithCreator;
+          } catch (error) {
+            console.error(
+              `Failed to fetch creator for coin ${coin.fid}:`,
+              error
+            );
+            return {
+              ...coin,
+              creator: undefined,
+            } as CoinWithCreator;
+          }
+        })
+      );
+      return coinsWithCreators;
+    } catch (error) {
+      console.error('Failed to fetch coins:', error);
+      return [] as CoinWithCreator[];
+    }
   },
   ['coins-with-data'],
   { revalidate: 300 }


### PR DESCRIPTION
## Summary
- handle errors from `supabaseService.getCoins()` in `CoinsList`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_685d449ef180833186c0566523aa39f8