### PR TITLE
Update coin duration to dynamic value

### DIFF
--- a/app/coins/[id]/page.tsx
+++ b/app/coins/[id]/page.tsx
@@ -85,7 +85,7 @@ export default async function GamePage({
         fid={coin.fid}
         creator={creator}
         coinId={coin.id}
-        timeoutSeconds={coin.duration ?? 10}
+        timeoutSeconds={coin.duration && coin.duration > 0 ? coin.duration : 10}
       />
     </div>
   );

--- a/app/coins/[id]/page.tsx
+++ b/app/coins/[id]/page.tsx
@@ -85,7 +85,7 @@ export default async function GamePage({
         fid={coin.fid}
         creator={creator}
         coinId={coin.id}
-        timeoutSeconds={coin.duration || 10}
+        timeoutSeconds={coin.duration ?? 10}
       />
     </div>
   );

--- a/app/coins/[id]/page.tsx
+++ b/app/coins/[id]/page.tsx
@@ -85,6 +85,7 @@ export default async function GamePage({
         fid={coin.fid}
         creator={creator}
         coinId={coin.id}
+        timeoutSeconds={coin.duration || 10}
       />
     </div>
   );

--- a/components/game-wrapper.tsx
+++ b/components/game-wrapper.tsx
@@ -18,7 +18,7 @@ interface GameWrapperProps {
   id: string;
   name: string;
   description: string;
-  timeoutSeconds?: number;
+  timeoutSeconds: number;
   coinAddress: string;
   imageUrl?: string;
   symbol: string;
@@ -31,7 +31,7 @@ export function GameWrapper({
   id,
   name,
   description,
-  timeoutSeconds = 10,
+  timeoutSeconds,
   coinAddress,
   imageUrl,
   symbol,
@@ -291,20 +291,21 @@ export function GameWrapper({
     }
   };
 
-  // Timer with forced timeout after 10 seconds
+  // Timer with forced timeout
   useEffect(() => {
-    if (!showGame || !timeoutSeconds) return;
+    if (!showGame) return;
 
     setRemainingTime(timeoutSeconds);
     const interval = setInterval(() => {
       setRemainingTime((prev) => {
-        if (prev <= 1) {
+        const currentTime = prev ?? 0;
+        if (currentTime <= 1) {
           // Signal the Game component to end itself
           console.log('⏰ GameWrapper: Time up, signaling game to end');
           setForceGameEnd(true);
           return 0;
         }
-        return prev - 1;
+        return currentTime - 1;
       });
     }, 1000);
 
@@ -339,15 +340,13 @@ export function GameWrapper({
             <span className="text-sm">Exit</span>
           </Button>
 
-          {timeoutSeconds && (
-            <div className="flex items-center gap-2 text-white/70 border-l border-white/20 pl-3">
-              <Clock size={14} />
-              <span className="text-sm font-mono">
-                {Math.floor(remainingTime / 60)}:
-                {(remainingTime % 60).toString().padStart(2, '0')}
-              </span>
-            </div>
-          )}
+          <div className="flex items-center gap-2 text-white/70 border-l border-white/20 pl-3">
+            <Clock size={14} />
+            <span className="text-sm font-mono">
+              {Math.floor((remainingTime ?? 0) / 60)}:
+              {((remainingTime ?? 0) % 60).toString().padStart(2, '0')}
+            </span>
+          </div>
         </div>
         <div className="flex-1">
           <Game

--- a/components/game.tsx
+++ b/components/game.tsx
@@ -36,7 +36,7 @@ const ERC20_ABI = [
 
 interface GameProps {
   id: string;
-  timeoutSeconds?: number;
+  timeoutSeconds: number;
   coinAddress: string;
   coinId: string;
   onRoundComplete?: (score: number) => void;
@@ -46,7 +46,7 @@ interface GameProps {
 
 export function Game({
   id,
-  timeoutSeconds = 10,
+  timeoutSeconds,
   coinAddress,
   coinId,
   onRoundComplete,

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -47,6 +47,7 @@ export type Coin = {
   description: string;
   parent: string;
   build_id: string;
+  duration?: number;
 };
 
 export type GamePlay = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,6 +20,7 @@ export interface Coin {
   created_at: string;
   updated_at: string;
   image: string;
+  duration?: number;
 }
 
 // Zora-specific coin data types


### PR DESCRIPTION
Use coin's duration for game timeout instead of hardcoded 10 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a custom game timer duration based on each coin’s settings.
* **Improvements**
  * The game timer is now always displayed and consistently uses the defined duration.
* **Bug Fixes**
  * Improved handling of timer state to prevent undefined or inconsistent timer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->