### PR TITLE
Add game wallet balance check

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -1,0 +1,9 @@
+{
+  "postEdit": {
+    "command": "npx prettier --write",
+    "args": ["${filePath}"],
+    "description": "Format code with Prettier after editing",
+    "includePatterns": ["**/*.{js,jsx,ts,tsx,json,css,scss,md}"],
+    "excludePatterns": ["node_modules/**", ".next/**", "dist/**"]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,11 @@ Critical env vars from README:
 - Custom middleware handles auth for API routes
 - OpenGraph images generated dynamically for coins
 - Background task processing with queue system
+
+## Code Formatting
+
+A Claude Code hook is configured in `.claude/hooks.json` to automatically format code using Prettier after edits. The hook applies to TypeScript, JavaScript, JSON, CSS, and Markdown files, using the project's Prettier configuration:
+
+- Single quotes, semicolons enabled
+- 2-space tabs, 80 character line width
+- ES5 trailing commas, LF line endings

--- a/app/api/wallet-balance/route.ts
+++ b/app/api/wallet-balance/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createPublicClient, http, Address } from 'viem';
+import { base } from 'viem/chains';
+
+const rpcUrl = process.env.RPC_URL!;
+
+const publicClient = createPublicClient({
+  chain: base,
+  transport: http(rpcUrl),
+});
+
+const ERC20_ABI = [
+  {
+    name: 'balanceOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ name: 'balance', type: 'uint256' }],
+  },
+  {
+    name: 'decimals',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: 'decimals', type: 'uint8' }],
+  },
+] as const;
+
+export async function POST(request: NextRequest) {
+  try {
+    const { coinAddress, walletAddress } = await request.json();
+
+    if (!coinAddress || !walletAddress) {
+      return NextResponse.json(
+        { error: 'Missing coinAddress or walletAddress' },
+        { status: 400 }
+      );
+    }
+
+    const [balance, decimals] = await Promise.all([
+      publicClient.readContract({
+        address: coinAddress as Address,
+        abi: ERC20_ABI,
+        functionName: 'balanceOf',
+        args: [walletAddress as Address],
+      }),
+      publicClient.readContract({
+        address: coinAddress as Address,
+        abi: ERC20_ABI,
+        functionName: 'decimals',
+      }),
+    ]);
+
+    const formatted = Number(balance) / 10 ** Number(decimals);
+
+    return NextResponse.json({ balance: formatted.toString() });
+  } catch (error) {
+    console.error('Error fetching wallet balance:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch balance' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/enhanced-auth-screen.tsx
+++ b/components/enhanced-auth-screen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Button } from './ui/button';
 import { LoadingSpinner } from './ui/loading-spinner';
 import { useMiniApp } from '@/contexts/miniapp-context';
@@ -50,6 +50,31 @@ export function EnhancedAuthScreen({
 
   const [manualRetryCount, setManualRetryCount] = useState(0);
   const [isCheckingAuth, setIsCheckingAuth] = useState(false);
+
+  // Handle wallet connection
+  const handleConnectWallet = useCallback(async () => {
+    try {
+      if (connectors && connectors.length > 0) {
+        connect({ connector: connectors[0] });
+      } else {
+        toast.error('No wallet connectors available');
+      }
+    } catch (error) {
+      console.error('Failed to connect wallet:', error);
+      toast.error('Failed to connect wallet');
+    }
+  }, [connect, connectors]);
+
+  // Handle Farcaster sign in
+  const handleFarcasterSignIn = useCallback(async () => {
+    try {
+      await signIn();
+      toast.success('Successfully signed in!');
+    } catch (error) {
+      console.error('Sign in failed:', error);
+      toast.error('Sign in failed. Please try again.');
+    }
+  }, [signIn]);
 
   // Authentication steps
   const [steps, setSteps] = useState<AuthStep[]>([
@@ -147,35 +172,12 @@ export function EnhancedAuthScreen({
     user,
     isSigningIn,
     signInError,
+    handleConnectWallet,
+    handleFarcasterSignIn,
   ]);
 
   // Check if all steps are complete
   const allStepsComplete = steps.every((step) => step.status === 'success');
-
-  // Handle wallet connection
-  const handleConnectWallet = async () => {
-    try {
-      if (connectors && connectors.length > 0) {
-        connect({ connector: connectors[0] });
-      } else {
-        toast.error('No wallet connectors available');
-      }
-    } catch (error) {
-      console.error('Failed to connect wallet:', error);
-      toast.error('Failed to connect wallet');
-    }
-  };
-
-  // Handle Farcaster sign in
-  const handleFarcasterSignIn = async () => {
-    try {
-      await signIn();
-      toast.success('Successfully signed in!');
-    } catch (error) {
-      console.error('Sign in failed:', error);
-      toast.error('Sign in failed. Please try again.');
-    }
-  };
 
   // Handle disconnecting wallet (for retry)
   const handleDisconnectWallet = () => {

--- a/components/game-wrapper.tsx
+++ b/components/game-wrapper.tsx
@@ -55,7 +55,6 @@ export function GameWrapper({
   const [coin, setCoin] = useState<Coin | null>(null);
   const [coinLoading, setCoinLoading] = useState(true);
   const [walletBalance, setWalletBalance] = useState<number | null>(null);
-  const [walletLoading, setWalletLoading] = useState(false);
   const { playStatus } = usePlayStatus();
 
   console.log('coinId', coinId);
@@ -74,7 +73,9 @@ export function GameWrapper({
       } catch (error) {
         console.error('Error fetching coin data:', error);
         sentryTracker.gameError(
-          error instanceof Error ? error : new Error('Failed to fetch coin data'),
+          error instanceof Error
+            ? error
+            : new Error('Failed to fetch coin data'),
           {
             game_id: id,
             game_name: name,
@@ -97,7 +98,6 @@ export function GameWrapper({
     const fetchWalletBalance = async () => {
       if (!coin?.wallet_address || !coin.coin_address) return;
       try {
-        setWalletLoading(true);
         const response = await fetch('/api/wallet-balance', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -113,8 +113,6 @@ export function GameWrapper({
         setWalletBalance(parseFloat(data.balance));
       } catch (err) {
         console.error('Error fetching wallet balance:', err);
-      } finally {
-        setWalletLoading(false);
       }
     };
 
@@ -124,11 +122,11 @@ export function GameWrapper({
   const handleScoreUpdate = (score: number) => {
     try {
       setCurrentScore(score);
-      
+
       // Check if max points reached for the first time
       if (coin?.max_points && score >= coin.max_points && !maxPointsReached) {
         setMaxPointsReached(true);
-        
+
         // Trigger haptic feedback for success
         try {
           sdk.haptics.impactOccurred('heavy');
@@ -484,7 +482,15 @@ export function GameWrapper({
       coinLoading,
       hasCoin: !!coin,
     });
-  }, [showGame, showResult, gameFinished, isCreatingScore, isScoreCreated, coinLoading, coin]);
+  }, [
+    showGame,
+    showResult,
+    gameFinished,
+    isCreatingScore,
+    isScoreCreated,
+    coinLoading,
+    coin,
+  ]);
 
   // Show loading state while fetching coin data
   if (coinLoading) {
@@ -540,23 +546,24 @@ export function GameWrapper({
         {/* Right side: Points display */}
         <div className="fixed top-4 right-4 z-50 rounded-full px-4 py-2 shadow-lg">
           <div className="flex items-center gap-2 text-white">
-            <div className={`flex items-center gap-2 transition-all duration-300 ${
-              maxPointsReached 
-                ? 'text-yellow-400 animate-pulse' 
-                : 'text-white/70'
-            }`}>
+            <div
+              className={`flex items-center gap-2 transition-all duration-300 ${
+                maxPointsReached
+                  ? 'text-yellow-400 animate-pulse'
+                  : 'text-white/70'
+              }`}
+            >
               {maxPointsReached ? (
                 <>
                   <Trophy size={14} className="animate-bounce" />
-                  <span className="text-sm font-bold">
-                    MAX REACHED! 🎉
-                  </span>
+                  <span className="text-sm font-bold">MAX REACHED! 🎉</span>
                 </>
               ) : (
                 <>
                   <Target size={14} />
                   <span className="text-sm font-mono">
-                    {currentScore.toLocaleString()}/{coin?.max_points?.toLocaleString() || '∞'}
+                    {currentScore.toLocaleString()}/
+                    {coin?.max_points?.toLocaleString() || '∞'}
                   </span>
                 </>
               )}

--- a/components/info.tsx
+++ b/components/info.tsx
@@ -218,7 +218,7 @@ export function Info({
     );
   }
 
-  if (walletBalance !== null && walletBalance <= 0) {
+  if (walletBalance != null && walletBalance <= 0) {
     return (
       <div className="min-h-screen bg-black flex items-center justify-center p-4">
         <div className="bg-black/20 backdrop-blur rounded-2xl shadow-xl p-8 text-center max-w-md border border-white/20 space-y-4">
@@ -437,8 +437,8 @@ export function Info({
                     Premium Access Required
                   </h3>
                   <p className="text-xs text-amber-300 mt-1">
-                    You need at least {formatNumber(coin.premium_threshold)} {symbol}{' '}
-                    tokens or wait{' '}
+                    You need at least {formatNumber(coin.premium_threshold)}{' '}
+                    {symbol} tokens or wait{' '}
                     {formatTimeUntil(playStatus.nextFreePlayTime!)} for your
                     next free play.
                   </p>
@@ -527,8 +527,8 @@ export function Info({
                     🎮 Unlock Unlimited Access
                   </h3>
                   <p className="text-xs text-white/70 leading-relaxed mb-3">
-                    Hold {formatNumber(coin.premium_threshold)} ${symbol} tokens to
-                    enjoy unlimited gameplay with no waiting periods or
+                    Hold {formatNumber(coin.premium_threshold)} ${symbol} tokens
+                    to enjoy unlimited gameplay with no waiting periods or
                     restrictions.
                   </p>
                   <div className="flex items-center gap-2 text-xs text-purple-300">

--- a/components/info.tsx
+++ b/components/info.tsx
@@ -32,6 +32,8 @@ interface InfoProps {
   onPlay: () => void;
   coinId: string;
   coin: Coin;
+  walletBalance?: number | null;
+  walletAddress?: string;
 }
 
 export function Info({
@@ -45,6 +47,8 @@ export function Info({
   onPlay,
   coinId,
   coin,
+  walletBalance,
+  walletAddress,
 }: InfoProps) {
   const { context } = useMiniApp();
   const { playStatus, isLoading, error, checkPlayStatus } = usePlayStatus();
@@ -209,6 +213,23 @@ export function Info({
       <div className="min-h-screen bg-black flex items-center justify-center p-4">
         <div className="bg-black/20 backdrop-blur rounded-2xl shadow-xl p-8 text-center max-w-md border border-white/20">
           <div className="text-white/70">Please enter a game description</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (walletBalance !== null && walletBalance <= 0) {
+    return (
+      <div className="min-h-screen bg-black flex items-center justify-center p-4">
+        <div className="bg-black/20 backdrop-blur rounded-2xl shadow-xl p-8 text-center max-w-md border border-white/20 space-y-4">
+          <div className="text-white">Game wallet is empty.</div>
+          {walletAddress && (
+            <div className="text-sm text-white/70 break-all">
+              Send {symbol} tokens to
+              <br />
+              {walletAddress}
+            </div>
+          )}
         </div>
       </div>
     );
@@ -801,6 +822,14 @@ export function Info({
                     {formatNumber(coin.premium_threshold)} ${symbol}
                   </span>
                 </div>
+                {walletBalance !== null && (
+                  <div className="flex justify-between items-center py-1 px-2 bg-black/20 rounded">
+                    <span className="text-yellow-300/70">Tokens Left:</span>
+                    <span className="text-yellow-200 font-mono">
+                      {formatNumber(walletBalance)} ${symbol}
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,6 +13,8 @@ export interface Coin {
   id: string;
   fid: number;
   coin_address: string;
+  wallet_address?: string;
+  wallet_id?: string;
   name: string;
   symbol: string;
   description: string;

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,6 +11,7 @@ export default async function middleware(req: NextRequest) {
     req.nextUrl.pathname === '/api/auth/sign-in' ||
     req.nextUrl.pathname === '/api/distributor' ||
     req.nextUrl.pathname === '/api/check-play-status' ||
+    req.nextUrl.pathname === '/api/daily-streak' ||
     req.nextUrl.pathname.startsWith('/api/og') ||
     req.nextUrl.pathname.startsWith('/api/coins') ||
     req.nextUrl.pathname.startsWith('/api/builds') ||


### PR DESCRIPTION
## Summary
- add coin wallet fields to types
- add API route to check game wallet balance
- show wallet balance on info page
- display screen when game wallet has no tokens

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644ff3a8448331a84d5c050835160d